### PR TITLE
Make formatting/sorting the same on both policies

### DIFF
--- a/cdk/policies/minimal_permissions_for_cdk_deploy_and_destroy.json
+++ b/cdk/policies/minimal_permissions_for_cdk_deploy_and_destroy.json
@@ -4,14 +4,14 @@
         {
             "Effect": "Allow",
             "Action": [
-                "cloudformation:GetTemplate",
                 "cloudformation:CreateChangeSet",
                 "cloudformation:DeleteChangeSet",
                 "cloudformation:DeleteStack",
-                "cloudformation:DescribeStacks",
                 "cloudformation:DescribeChangeSet",
+                "cloudformation:DescribeStackEvents",
+                "cloudformation:DescribeStacks",
                 "cloudformation:ExecuteChangeSet",
-                "cloudformation:DescribeStackEvents"
+                "cloudformation:GetTemplate"
             ],
             "Resource": [
                 "arn:aws:cloudformation:*:<YOUR_ACCOUNT>:stack/<YOUR_STACK_NAME>-eks-stack/*",
@@ -21,9 +21,9 @@
         {
             "Effect": "Allow",
             "Action": [
-                "s3:ListBucket",
+                "s3:*Object",
                 "s3:GetBucketLocation",
-                "s3:*Object"
+                "s3:ListBucket"
             ],
             "Resource": [
                 "arn:aws:s3:::cdktoolkit-stagingbucket-*"
@@ -34,12 +34,12 @@
             "Action": [
                 "s3:CreateBucket",
                 "s3:DeleteBucket",
-                "s3:ListBucket",
-                "s3:GetBucketLocation",
-                "s3:PutEncryptionConfiguration",
-                "s3:PutBucketPolicy",
                 "s3:DeleteBucketPolicy",
-                "s3:PutBucketTagging"
+                "s3:GetBucketLocation",
+                "s3:ListBucket",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketTagging",
+                "s3:PutEncryptionConfiguration"
             ],
             "Condition": {
                 "ForAnyValue:StringEquals": {
@@ -55,23 +55,23 @@
         {
             "Effect": "Allow",
             "Action": [
-                "iam:CreateRole",
-                "iam:GetRole",
-                "iam:PassRole",
-                "iam:DeleteRole",
-                "iam:GetPolicy",
-                "iam:DeletePolicy",
-                "iam:CreatePolicy",
-                "iam:ListPolicyVersions",
-                "iam:AttachRolePolicy",
-                "iam:DetachRolePolicy",
-                "iam:PutRolePolicy",
-                "iam:DeleteRolePolicy",
-                "iam:ListAttachedRolePolicies",
-                "iam:CreateInstanceProfile",
-                "iam:DeleteInstanceProfile",
-                "iam:GetInstanceProfile",
                 "iam:AddRoleToInstanceProfile",
+                "iam:AttachRolePolicy",
+                "iam:CreateInstanceProfile",
+                "iam:CreatePolicy",
+                "iam:CreateRole",
+                "iam:DeleteInstanceProfile",
+                "iam:DeletePolicy",
+                "iam:DeleteRole",
+                "iam:DeleteRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:GetInstanceProfile",
+                "iam:GetPolicy",
+                "iam:GetRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListPolicyVersions",
+                "iam:PassRole",
+                "iam:PutRolePolicy",
                 "iam:RemoveRoleFromInstanceProfile"
             ],
             "Condition": {
@@ -92,12 +92,12 @@
             "Action": [
                 "lambda:CreateFunction",
                 "lambda:DeleteFunction",
-                "lambda:GetFunction",
-                "lambda:InvokeFunction",
-                "lambda:PublishLayerVersion",
-                "lambda:GetLayerVersion",
                 "lambda:DeleteLayerVersion",
-                "lambda:GetLayerVersionPolicy"
+                "lambda:GetFunction",
+                "lambda:GetLayerVersion",
+                "lambda:GetLayerVersionPolicy",
+                "lambda:InvokeFunction",
+                "lambda:PublishLayerVersion"
             ],
             "Condition": {
                 "ForAnyValue:StringEquals": {
@@ -133,11 +133,11 @@
         {
             "Effect": "Allow",
             "Action": [
-                "eks:TagResource",
-                "eks:UntagResource",
                 "eks:CreateNodegroup",
                 "eks:DeleteNodegroup",
-                "eks:DescribeNodegroup"
+                "eks:DescribeNodegroup",
+                "eks:TagResource",
+                "eks:UntagResource"
             ],
             "Resource": [
                 "arn:aws:eks:*:<YOUR_ACCOUNT>:cluster/*"
@@ -146,9 +146,9 @@
         {
             "Effect": "Allow",
             "Action": [
-                "ssm:PutParameter",
-                "ssm:DeleteParameter",
                 "ssm:AddTagsToResource",
+                "ssm:DeleteParameter",
+                "ssm:PutParameter",
                 "ssm:RemoveTagsFromResource"
             ],
             "Condition": {
@@ -174,15 +174,15 @@
         {
             "Effect": "Allow",
             "Action": [
-                "backup:TagResource",
-                "backup:ListTags",
                 "backup:*BackupVault*",
                 "backup:CreateBackupPlan",
-                "backup:DeleteBackupPlan",
-                "backup:GetBackupPlan",
                 "backup:CreateBackupSelection",
+                "backup:DeleteBackupPlan",
+                "backup:DeleteBackupSelection",
+                "backup:GetBackupPlan",
                 "backup:GetBackupSelection",
-                "backup:DeleteBackupSelection"
+                "backup:ListTags",
+                "backup:TagResource"
             ],
             "Condition": {
                 "ForAnyValue:StringEquals": {

--- a/cdk/policies/minimal_permissions_for_cf_ui_and_terraform.json
+++ b/cdk/policies/minimal_permissions_for_cf_ui_and_terraform.json
@@ -1,253 +1,253 @@
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "cloudformation:GetTemplate",
-        "cloudformation:CreateChangeSet",
-        "cloudformation:DeleteChangeSet",
-        "cloudformation:DeleteStack",
-        "cloudformation:DescribeStacks",
-        "cloudformation:DescribeChangeSet",
-        "cloudformation:ExecuteChangeSet",
-        "cloudformation:DescribeStackEvents"
-      ],
-      "Resource": [
-        "arn:aws:cloudformation:*:<YOUR_ACCOUNT>:stack/<YOUR_STACK_NAME>-*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetBucketLocation",
-        "s3:*Object"
-      ],
-      "Resource": [
-        "arn:aws:s3:::*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:CreateBucket",
-        "s3:DeleteBucket",
-        "s3:ListBucket",
-        "s3:GetBucketLocation",
-        "s3:PutEncryptionConfiguration",
-        "s3:PutBucketPolicy",
-        "s3:DeleteBucketPolicy",
-        "s3:PutBucketTagging"
-      ],
-      "Resource": [
-        "arn:aws:s3:::<YOUR_STACK_NAME>-*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iam:CreateRole",
-        "iam:PassRole",
-        "iam:DeleteRole",
-        "iam:GetPolicy",
-        "iam:DeletePolicy",
-        "iam:CreatePolicy",
-        "iam:ListPolicyVersions",
-        "iam:AttachRolePolicy",
-        "iam:DetachRolePolicy",
-        "iam:PutRolePolicy",
-        "iam:DeleteRolePolicy",
-        "iam:ListAttachedRolePolicies",
-        "iam:CreateInstanceProfile",
-        "iam:DeleteInstanceProfile",
-        "iam:GetInstanceProfile",
-        "iam:AddRoleToInstanceProfile",
-        "iam:RemoveRoleFromInstanceProfile",
-        "iam:Tag*",
-        "iam:Untag*"
-      ],
-      "Resource": [
-        "arn:aws:iam::<YOUR_ACCOUNT>:policy/<YOUR_STACK_NAME>-*",
-        "arn:aws:iam::<YOUR_ACCOUNT>:role/<YOUR_STACK_NAME>-*",
-        "arn:aws:iam::<YOUR_ACCOUNT>:instance-profile/<YOUR_STACK_NAME>-*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "lambda:InvokeFunction"
-      ],
-      "Resource": [
-        "arn:aws:lambda:*:<YOUR_ACCOUNT>:function:<YOUR_STACK_NAME>-*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "lambda:CreateFunction",
-        "lambda:DeleteFunction",
-        "lambda:GetFunction",
-        "lambda:InvokeFunction",
-        "lambda:PublishLayerVersion",
-        "lambda:GetLayerVersion",
-        "lambda:DeleteLayerVersion",
-        "lambda:GetLayerVersionPolicy"
-      ],
-      "Condition": {
-        "ForAnyValue:StringEquals": {
-          "aws:CalledVia": [
-            "cloudformation.amazonaws.com"
-          ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cloudformation:CreateChangeSet",
+                "cloudformation:DeleteChangeSet",
+                "cloudformation:DeleteStack",
+                "cloudformation:DescribeChangeSet",
+                "cloudformation:DescribeStackEvents",
+                "cloudformation:DescribeStacks",
+                "cloudformation:ExecuteChangeSet",
+                "cloudformation:GetTemplate"
+            ],
+            "Resource": [
+                "arn:aws:cloudformation:*:<YOUR_ACCOUNT>:stack/<YOUR_STACK_NAME>-*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:*Object",
+                "s3:GetBucketLocation",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:GetBucketLocation",
+                "s3:ListBucket",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketTagging",
+                "s3:PutEncryptionConfiguration"
+            ],
+            "Resource": [
+                "arn:aws:s3:::<YOUR_STACK_NAME>-*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:AddRoleToInstanceProfile",
+                "iam:AttachRolePolicy",
+                "iam:CreateInstanceProfile",
+                "iam:CreatePolicy",
+                "iam:CreateRole",
+                "iam:DeleteInstanceProfile",
+                "iam:DeletePolicy",
+                "iam:DeleteRole",
+                "iam:DeleteRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:GetInstanceProfile",
+                "iam:GetPolicy",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListPolicyVersions",
+                "iam:PassRole",
+                "iam:PutRolePolicy",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:Tag*",
+                "iam:Untag*"
+            ],
+            "Resource": [
+                "arn:aws:iam::<YOUR_ACCOUNT>:policy/<YOUR_STACK_NAME>-*",
+                "arn:aws:iam::<YOUR_ACCOUNT>:role/<YOUR_STACK_NAME>-*",
+                "arn:aws:iam::<YOUR_ACCOUNT>:instance-profile/<YOUR_STACK_NAME>-*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "lambda:InvokeFunction"
+            ],
+            "Resource": [
+                "arn:aws:lambda:*:<YOUR_ACCOUNT>:function:<YOUR_STACK_NAME>-*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:DeleteLayerVersion",
+                "lambda:GetFunction",
+                "lambda:GetLayerVersion",
+                "lambda:GetLayerVersionPolicy",
+                "lambda:InvokeFunction",
+                "lambda:PublishLayerVersion"
+            ],
+            "Condition": {
+                "ForAnyValue:StringEquals": {
+                    "aws:CalledVia": [
+                        "cloudformation.amazonaws.com"
+                    ]
+                }
+            },
+            "Resource": [
+                "arn:aws:lambda:*:<YOUR_ACCOUNT>:function:<YOUR_STACK_NAME>-*",
+                "arn:aws:lambda:*:<YOUR_ACCOUNT>:layer:*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "states:CreateStateMachine",
+                "states:DeleteStateMachine",
+                "states:TagResource",
+                "states:UntagResource"
+            ],
+            "Condition": {
+                "ForAnyValue:StringEquals": {
+                    "aws:CalledVia": [
+                        "cloudformation.amazonaws.com"
+                    ]
+                }
+            },
+            "Resource": [
+                "arn:aws:states:*:<YOUR_ACCOUNT>:stateMachine:Provider*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:AddTagsToResource",
+                "ssm:DeleteParameter",
+                "ssm:PutParameter",
+                "ssm:RemoveTagsFromResource"
+            ],
+            "Condition": {
+                "ForAnyValue:StringEquals": {
+                    "aws:CalledVia": [
+                        "cloudformation.amazonaws.com"
+                    ]
+                }
+            },
+            "Resource": [
+                "arn:aws:ssm:*:<YOUR_ACCOUNT>:parameter/CFN*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParameters"
+            ],
+            "Resource": [
+                "arn:aws:ssm:*::parameter/aws/service/eks/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "backup:*BackupPlan",
+                "backup:*BackupVault*",
+                "backup:CreateBackupSelection",
+                "backup:DeleteBackupSelection",
+                "backup:GetBackupSelection",
+                "backup:ListTags",
+                "backup:TagResource"
+            ],
+            "Condition": {
+                "ForAnyValue:StringEquals": {
+                    "aws:CalledVia": [
+                        "cloudformation.amazonaws.com"
+                    ]
+                }
+            },
+            "Resource": [
+                "arn:aws:backup:*:<YOUR_ACCOUNT>:backup-vault:<YOUR_STACK_NAME>-efs",
+                "arn:aws:backup:*:<YOUR_ACCOUNT>:backup-plan:*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "backup-storage:MountCapsule",
+                "elasticfilesystem:CreateAccessPoint",
+                "elasticfilesystem:CreateFileSystem",
+                "elasticfilesystem:DeleteAccessPoint",
+                "elasticfilesystem:DeleteFileSystem",
+                "elasticfilesystem:DescribeAccessPoints",
+                "elasticfilesystem:DescribeFileSystems",
+                "kms:CreateGrant",
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:GenerateDataKey",
+                "kms:RetireGrant"
+            ],
+            "Condition": {
+                "ForAnyValue:StringEquals": {
+                    "aws:CalledVia": [
+                        "cloudformation.amazonaws.com"
+                    ]
+                }
+            },
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:CreateAutoScalingGroup",
+                "autoscaling:DeleteAutoScalingGroup",
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeScalingActivities",
+                "autoscaling:UpdateAutoScalingGroup",
+                "ec2:*InternetGateway*",
+                "ec2:*NatGateway*",
+                "ec2:*NetworkInterface*",
+                "ec2:*Route*",
+                "ec2:*SecurityGroupEgress",
+                "ec2:*SecurityGroupIngress",
+                "ec2:*Subnet*",
+                "ec2:*Vpc*",
+                "ec2:AllocateAddress",
+                "ec2:CreateLaunchTemplate",
+                "ec2:CreateSecurityGroup",
+                "ec2:CreateTags",
+                "ec2:DeleteLaunchTemplate",
+                "ec2:DeleteSecurityGroup",
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeLaunchTemplates",
+                "ec2:DescribeSecurityGroups",
+                "ec2:GetLaunchTemplateData",
+                "ec2:ReleaseAddress",
+                "ec2:RunInstances",
+                "eks:CreateNodegroup",
+                "eks:DeleteNodegroup",
+                "eks:DescribeNodegroup",
+                "eks:TagResource",
+                "eks:UntagResource",
+                "elasticfilesystem:Backup",
+                "elasticfilesystem:CreateMountTarget",
+                "elasticfilesystem:DeleteMountTarget",
+                "elasticfilesystem:DescribeMountTargets",
+                "iam:GetRole",
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "*"
+            ]
         }
-      },
-      "Resource": [
-        "arn:aws:lambda:*:<YOUR_ACCOUNT>:function:<YOUR_STACK_NAME>-*",
-        "arn:aws:lambda:*:<YOUR_ACCOUNT>:layer:*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "states:CreateStateMachine",
-        "states:DeleteStateMachine",
-        "states:TagResource",
-        "states:UntagResource"
-      ],
-      "Condition": {
-        "ForAnyValue:StringEquals": {
-          "aws:CalledVia": [
-            "cloudformation.amazonaws.com"
-          ]
-        }
-      },
-      "Resource": [
-        "arn:aws:states:*:<YOUR_ACCOUNT>:stateMachine:Provider*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ssm:PutParameter",
-        "ssm:DeleteParameter",
-        "ssm:AddTagsToResource",
-        "ssm:RemoveTagsFromResource"
-      ],
-      "Condition": {
-        "ForAnyValue:StringEquals": {
-          "aws:CalledVia": [
-            "cloudformation.amazonaws.com"
-          ]
-        }
-      },
-      "Resource": [
-        "arn:aws:ssm:*:<YOUR_ACCOUNT>:parameter/CFN*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ssm:GetParameters"
-      ],
-      "Resource": [
-        "arn:aws:ssm:*::parameter/aws/service/eks/*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "backup:TagResource",
-        "backup:ListTags",
-        "backup:*BackupVault*",
-        "backup:*BackupPlan",
-        "backup:CreateBackupSelection",
-        "backup:GetBackupSelection",
-        "backup:DeleteBackupSelection"
-      ],
-      "Condition": {
-        "ForAnyValue:StringEquals": {
-          "aws:CalledVia": [
-            "cloudformation.amazonaws.com"
-          ]
-        }
-      },
-      "Resource": [
-        "arn:aws:backup:*:<YOUR_ACCOUNT>:backup-vault:<YOUR_STACK_NAME>-efs",
-        "arn:aws:backup:*:<YOUR_ACCOUNT>:backup-plan:*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "backup-storage:MountCapsule",
-        "elasticfilesystem:CreateAccessPoint",
-        "elasticfilesystem:CreateFileSystem",
-        "elasticfilesystem:DeleteAccessPoint",
-        "elasticfilesystem:DeleteFileSystem",
-        "elasticfilesystem:DescribeAccessPoints",
-        "elasticfilesystem:DescribeFileSystems",
-        "kms:CreateGrant",
-        "kms:Decrypt",
-        "kms:DescribeKey",
-        "kms:GenerateDataKey",
-        "kms:RetireGrant"
-      ],
-      "Condition": {
-        "ForAnyValue:StringEquals": {
-          "aws:CalledVia": [
-            "cloudformation.amazonaws.com"
-          ]
-        }
-      },
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "autoscaling:CreateAutoScalingGroup",
-        "autoscaling:DeleteAutoScalingGroup",
-        "autoscaling:DescribeAutoScalingGroups",
-        "autoscaling:DescribeScalingActivities",
-        "autoscaling:UpdateAutoScalingGroup",
-        "ec2:*InternetGateway*",
-        "ec2:*NatGateway*",
-        "ec2:*NetworkInterface*",
-        "ec2:*Route*",
-        "ec2:*SecurityGroupEgress",
-        "ec2:*SecurityGroupIngress",
-        "ec2:*Subnet*",
-        "ec2:*Vpc*",
-        "ec2:AllocateAddress",
-        "ec2:CreateLaunchTemplate",
-        "ec2:CreateSecurityGroup",
-        "ec2:CreateTags",
-        "ec2:DeleteLaunchTemplate",
-        "ec2:DeleteSecurityGroup",
-        "ec2:DescribeAccountAttributes",
-        "ec2:DescribeAvailabilityZones",
-        "ec2:DescribeLaunchTemplates",
-        "ec2:DescribeSecurityGroups",
-        "ec2:GetLaunchTemplateData",
-        "ec2:ReleaseAddress",
-        "ec2:RunInstances",
-        "ec2:describeAddresses",
-        "eks:TagResource",
-        "eks:UntagResource",
-        "eks:CreateNodegroup",
-        "eks:DeleteNodegroup",
-        "eks:DescribeNodegroup",
-        "elasticfilesystem:Backup",
-        "elasticfilesystem:CreateMountTarget",
-        "elasticfilesystem:DeleteMountTarget",
-        "elasticfilesystem:DescribeMountTargets",
-        "iam:GetRole",
-        "s3:GetBucketLocation",
-        "s3:GetObject",
-        "s3:ListBucket"
-      ],
-      "Resource": [
-        "*"
-      ]
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
The two policies were sort of hard to compare as they were sorted differently and had different levels of indentation. I just loaded this into a python dict and spat it back out so they'd be the same.