### PR TITLE
Add ECR policies (PLAT-2132)

### DIFF
--- a/iam_policies/minimal_permissions_for_cf_ui_and_terraform.json
+++ b/iam_policies/minimal_permissions_for_cf_ui_and_terraform.json
@@ -204,6 +204,23 @@
         {
             "Effect": "Allow",
             "Action": [
+                "ecr:CreateRepository",
+                "ecr:DeleteRepository"
+            ],
+            "Condition": {
+                "ForAnyValue:StringEquals": {
+                    "aws:CalledVia": [
+                        "cloudformation.amazonaws.com"
+                    ]
+                }
+            },
+            "Resource": [
+                "arn:aws:ecr:*:<YOUR_ACCOUNT>:repository/<YOUR_STACK_NAME>*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
                 "autoscaling:CreateAutoScalingGroup",
                 "autoscaling:DeleteAutoScalingGroup",
                 "autoscaling:DescribeAutoScalingGroups",


### PR DESCRIPTION
Goals:
- We want to give access to the same deployment images.
- We definitely want some specific EKS images. This comes for free because they are public and IAM doesn't affect them.
- We do not want to give a blanket access to each and every domino images in the same account because there can be images that are not in a deployment but still restricted.
- We do not care to limit to the account, this probably happens automatically because of "private" thing, we just do not want access to all images in the same account unless explicitly allowed.

Change summary:
1. Add ECR creation policy to the deploying role (this is not used right now but might be useful later).
2. Add explicit ECR deny policy that will prohibit pulling images from the same account if they are not marked as same deployment.
3. Make NodeGroup role names shorter and more human-readable.

Tests (our deploy: denis-test2):
- 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/coredns:v1.8.0-eksbuild.1 - allow
- 890728157128.dkr.ecr.us-west-2.amazonaws.com/denis-test2/nucleus:latest tags [denis-test2] - allow
- 890728157128.dkr.ecr.us-west-2.amazonaws.com/denis-test2/nucleus:latest tags [] - deny
- 890728157128.dkr.ecr.us-west-2.amazonaws.com/denis-test2-internal:latest tags [denis-test2-internal] - deny