### PR TITLE
Improvements for custom ami and user data handling (PLAT-2266 and PLAT-2354)

### DIFF
--- a/cdk/domino_cdk/eks_stack.py
+++ b/cdk/domino_cdk/eks_stack.py
@@ -491,9 +491,10 @@ class DominoEksStack(cdk.Stack):
                 lts = None
 
             indexed_name = f"{self.name}-{name}-{az}"
+            indexed_id = f"{self.name}-{name}-{i}"
             key_name = cfg.get("key_name", None)
             self.cluster.add_nodegroup_capacity(
-                indexed_name,  # this might be dangerous
+                indexed_id,  # this might be dangerous
                 nodegroup_name=indexed_name,
                 capacity_type=eks.CapacityType.SPOT if cfg["spot"] else eks.CapacityType.ON_DEMAND,
                 min_size=cfg["min_size"],
@@ -546,9 +547,10 @@ class DominoEksStack(cdk.Stack):
         scope = cdk.Construct(self, f"UnmanagedNodeGroup{name}")
         for i, az in enumerate(self.vpc.availability_zones[:max_nodegroup_azs]):
             indexed_name = f"{self.name}-{name}-{az}"
+            indexed_id = f"{self.name}-{name}-{i}"
             asg = aws_autoscaling.AutoScalingGroup(
                 scope,
-                indexed_name,
+                indexed_id,
                 auto_scaling_group_name=indexed_name,
                 instance_type=ec2.InstanceType(cfg["instance_types"][0]),
                 machine_image=machine_image,

--- a/cdk/domino_cdk/eks_stack.py
+++ b/cdk/domino_cdk/eks_stack.py
@@ -1,7 +1,7 @@
 from os.path import isfile
 from re import MULTILINE
 from re import split as re_split
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, List, Union
 
 import aws_cdk.aws_backup as backup
 import aws_cdk.aws_ec2 as ec2
@@ -298,11 +298,13 @@ class DominoEksStack(cdk.Stack):
         max_nodegroup_azs = self.config["eks"]["max_nodegroup_azs"]
 
         for name, cfg in self.config["eks"]["managed_nodegroups"].items():
-            cfg["labels"] = {**cfg["labels"], **self.config["eks"]["global_node_labels"]}
+            if not cfg.get("ami_id"):
+                cfg["labels"] = {**cfg["labels"], **self.config["eks"]["global_node_labels"]}
             self.provision_managed_nodegroup(name, cfg, max_nodegroup_azs)
 
         for name, cfg in self.config["eks"]["nodegroups"].items():
-            cfg["labels"] = {**cfg["labels"], **self.config["eks"]["global_node_labels"]}
+            if not cfg.get("ami_id"):
+                cfg["labels"] = {**cfg["labels"], **self.config["eks"]["global_node_labels"]}
             self.provision_unmanaged_nodegroup(name, cfg, max_nodegroup_azs, eks_version)
 
     def provision_eks_iam_policies(self):
@@ -400,17 +402,78 @@ class DominoEksStack(cdk.Stack):
             managed_policies=managed_policies,
         )
 
+    def _get_machine_image(self, cfg_name: str, cfg: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:
+        ami_id = cfg.get("ami_id")
+        user_data = cfg.get("user_data")
+        if ami_id and not user_data:
+            raise Exception("User data must be provided when specifying a custom AMI")
+        if ami_id and (cfg.get("ssm_agent") or cfg.get("labels") or cfg.get("taints")):
+            raise Exception(
+                "ssm_agent, labels and taints cannot be automatically configured when specifying a custom AMI. "
+                "You need to configure all of this using user_data."
+            )
+        return ami_id, user_data
+
+    def _handle_user_data(
+        self, name: str, custom_ami: bool, cfg: dict, user_data_list: List[Union[ec2.UserData, str]]
+    ) -> Optional[ec2.UserData]:
+        proceed: bool = False
+        mime_user_data = ec2.MultipartUserData()
+
+        # If we are using default EKS image, tweak kubelet
+        if not custom_ami:
+            mime_user_data.add_part(
+                ec2.MultipartBody.from_user_data(
+                    ec2.UserData.custom(
+                        'KUBELET_CONFIG=/etc/kubernetes/kubelet/kubelet-config.json\n'
+                        'echo "$(jq \'.eventRecordQPS=0\' $KUBELET_CONFIG)" > $KUBELET_CONFIG'
+                    )
+                ),
+            )
+            proceed = True
+        if cfg.get("ssm_agent"):
+            mime_user_data.add_part(
+                ec2.MultipartBody.from_user_data(
+                    ec2.UserData.custom(
+                        "yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm",
+                    )
+                ),
+            )
+            proceed = True
+        for ud in user_data_list:
+            if isinstance(ud, str):
+                mime_user_data.add_part(
+                    ec2.MultipartBody.from_user_data(
+                        ec2.UserData.custom(
+                            cdk.Fn.sub(
+                                ud,
+                                {
+                                    "NodegroupName": name,
+                                    "StackName": self.name,
+                                    "ClusterName": self.cluster.cluster_name,
+                                },
+                            ),
+                        ),
+                    ),
+                )
+            if isinstance(ud, ec2.UserData):
+                mime_user_data.add_part(ec2.MultipartBody.from_user_data(ud))
+            proceed = True
+
+        if not proceed:
+            return None
+
+        return mime_user_data
+
     def provision_managed_nodegroup(self, name: str, cfg: dict, max_nodegroup_azs: int) -> None:
-        # managed nodegroups
         ami_id, user_data = self._get_machine_image(name, cfg)
-        machine_image: Optional[ec2.IMachineImage] = None
-        if ami_id:
-            machine_image = ec2.MachineImage.generic_linux({self.region: ami_id})
+        machine_image: Optional[ec2.IMachineImage] = (
+            ec2.MachineImage.generic_linux({self.region: ami_id}) if ami_id else None
+        )
+        mime_user_data: Optional[ec2.UserData] = self._handle_user_data(name, ami_id, cfg, [user_data])
 
         for i, az in enumerate(self.vpc.availability_zones[:max_nodegroup_azs]):
-            disk_size = cfg.get("disk_size", None)
-            lts: Optional[eks.LaunchTemplateSpec] = None
-            if machine_image:
+            if machine_image or mime_user_data:
                 lt = ec2.LaunchTemplate(
                     self.cluster,
                     f"LaunchTemplate{name}{i}",
@@ -425,20 +488,23 @@ class DominoEksStack(cdk.Stack):
                         )
                     ],
                     machine_image=machine_image,
-                    user_data=ec2.UserData.custom(cdk.Fn.sub(user_data, {"ClusterName": self.cluster.cluster_name})),
+                    user_data=mime_user_data,
                 )
                 lts = eks.LaunchTemplateSpec(id=lt.launch_template_id, version=lt.version_number)
                 disk_size = None
+            else:
+                disk_size = cfg["disk_size"]
+                lts = None
 
             key_name = cfg.get("key_name", None)
             self.cluster.add_nodegroup_capacity(
-                f"{name}-{i}",  # this might be dangerous
-                nodegroup_name=f"{self.name}-{name}-{az}",  # this might be dangerous
+                f"{self.name}-{name}-{i}",  # this might be dangerous
+                nodegroup_name=f"{self.name}-{name}-{i}",
                 capacity_type=eks.CapacityType.SPOT if cfg["spot"] else eks.CapacityType.ON_DEMAND,
-                disk_size=disk_size,
                 min_size=cfg["min_size"],
                 max_size=cfg["max_size"],
                 desired_size=cfg["desired_size"],
+                disk_size=disk_size,
                 subnets=ec2.SubnetSelection(
                     subnet_group_name=self.private_subnet_name,
                     availability_zones=[az],
@@ -451,28 +517,14 @@ class DominoEksStack(cdk.Stack):
                 remote_access=eks.NodegroupRemoteAccess(ssh_key_name=key_name) if key_name else None,
             )
 
-    def _get_machine_image(self, cfg_name: str, cfg: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:
-        image = cfg.get("machine_image", {})
-
-        if not image:
-            return None, None
-
-        ami_id = image.get("ami_id")
-        user_data = image.get("user_data")
-
-        if ami_id and user_data:
-            return ami_id, user_data
-
-        raise ValueError(f"{cfg_name}: ami_id and user_data must both be specified")
-
     def provision_unmanaged_nodegroup(
         self, name: str, cfg: dict, max_nodegroup_azs: int, eks_version: eks.KubernetesVersion
     ) -> None:
         ami_id, user_data = self._get_machine_image(name, cfg)
 
         machine_image = (
-            ec2.MachineImage.generic_linux({self.region: ami_id}, user_data=ec2.UserData.custom(user_data))
-            if ami_id and user_data
+            ec2.MachineImage.generic_linux({self.region: ami_id})
+            if ami_id
             else eks.EksOptimizedImage(
                 cpu_arch=eks.CpuArch.X86_64,
                 kubernetes_version=eks_version.version,
@@ -498,7 +550,6 @@ class DominoEksStack(cdk.Stack):
 
         scope = cdk.Construct(self, f"UnmanagedNodeGroup{name}")
         for i, az in enumerate(self.vpc.availability_zones[:max_nodegroup_azs]):
-
             indexed_name = f"{self.name}-{name}-{i}"
             asg = aws_autoscaling.AutoScalingGroup(
                 scope,
@@ -529,6 +580,8 @@ class DominoEksStack(cdk.Stack):
             ).items():
                 cdk.Tags.of(asg).add(str(k), str(v), apply_to_launched_instances=True)
 
+            mime_user_data = self._handle_user_data(name, ami_id, cfg, [asg.user_data, user_data])
+
             lt = ec2.LaunchTemplate(
                 scope,
                 f"LaunchTemplate{i}",
@@ -546,7 +599,7 @@ class DominoEksStack(cdk.Stack):
                 instance_type=ec2.InstanceType(cfg["instance_types"][0]),
                 key_name=cfg.get("key_name", None),
                 machine_image=machine_image,
-                user_data=asg.user_data,
+                user_data=mime_user_data,
                 security_group=self.unmanaged_sg,
             )
             # mimic adding the security group via the ASG during connect_auto_scaling_group_capacity
@@ -579,9 +632,9 @@ class DominoEksStack(cdk.Stack):
             )
 
             options: dict[str, Any] = {
-                "bootstrap_enabled": user_data is None,
+                "bootstrap_enabled": ami_id is None,
             }
-            if not user_data:
+            if not ami_id:
                 extra_args: list[str] = []
                 if labels := cfg.get("labels"):
                     extra_args.append(
@@ -593,17 +646,6 @@ class DominoEksStack(cdk.Stack):
                         "--register-with-taints={}".format(",".join(["{}={}".format(k, v) for k, v in taints.items()]))
                     )
                 options["bootstrap_options"] = eks.BootstrapOptions(kubelet_extra_args=" ".join(extra_args))
-
-                if cfg["ssm_agent"]:
-                    # We can only access this as an attribute of either the launch template or asg (both are the
-                    # same object)as we are getting it from the default user_data included in the standard EKS ami
-                    lt.user_data.add_on_exit_commands(
-                        "yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm"
-                    )
-            elif cfg["ssm_agent"] or cfg.get("labels") or cfg.get("taints"):
-                raise ValueError(
-                    "ssm_agent, labels and taints will not be automatically confiugured when user_data is specified in the config. Please set this up accordingly in your user_data."
-                )
 
             self.cluster.connect_auto_scaling_group_capacity(asg, **options)
 

--- a/cdk/domino_cdk/util.py
+++ b/cdk/domino_cdk/util.py
@@ -13,7 +13,7 @@ class ExternalCommandException(Exception):
     """Exception running spawned external commands"""
 
 
-class DominoCdkUtil():
+class DominoCdkUtil:
     @classmethod
     def generate_asset_parameters(cls, asset_dir: str, asset_bucket: str, stack_name: str, manifest_file: str = None):
         with open(manifest_file or path_join(asset_dir, "manifest.json")) as f:


### PR DESCRIPTION
If ami_id is not specified in managed user group, EKS automatically provides latest and greatest Linux2 image. AWS documentation vague hints that the nodes will be also automatically upgraded if a newer and greater Linux2 image emerges.

In this case EKS provides its bootstrap logic as a part in MIME/multipart and demands that any other user data was also in MIME/multipart so it can join the parts together.

user data is fed to cloud_init and MIME/multipart is one of the formats where multiple scripts are passed as parts.

Benefits for managed node groups:
1. We can have true auto-upgrading fully managed autoscaling group.
2. We can add "install ssm" logic and "tweak QPS in kubelet" as separate bash scripts that do not intersect with any custom user data.

Also, we can improve unmanaged node groups:
1. We can add "install ssm" logic and "tweak QPS in kubelet" as separate bash scripts that do not intersect with any custom user data (compared to the old approach that injects custom user data as a bash function in front of the standard script).
2. We can unify user data handling for managed and unmanaged groups.

BTW. For unmanaged groups. 
* there is no default user data script in default AMI. 
* all bootstrap code is generated by CDK and is part of the generated CF template 
* It is not even EKS-provided.

