### PR TITLE
Adding IAM roles for K8s service accounts (PLAT-2264)

### DIFF
--- a/cdk/domino_cdk/agent.py
+++ b/cdk/domino_cdk/agent.py
@@ -2,6 +2,7 @@ from typing import Dict, List
 
 from aws_cdk.aws_s3 import Bucket
 
+
 def generate_install_config(
     name: str,
     aws_region: str,

--- a/cdk/domino_cdk/agent.py
+++ b/cdk/domino_cdk/agent.py
@@ -1,7 +1,6 @@
 from typing import Dict, List
 
-from domino_cdk import config
-
+from aws_cdk.aws_s3 import Bucket
 
 def generate_install_config(
     name: str,
@@ -9,7 +8,7 @@ def generate_install_config(
     eks_cluster_name: str,
     pod_cidr: str,
     global_node_selectors: Dict[str, str],
-    buckets: List[config.S3.Bucket],
+    buckets: List[Bucket],
     efs_fs_ap_id: str,
     r53_zone_ids: str,
     r53_owner_id: str,

--- a/cdk/domino_cdk/aws_configurator.py
+++ b/cdk/domino_cdk/aws_configurator.py
@@ -22,13 +22,10 @@ manifests = [
 # deprovisoning efs backups/route53, tagging the eks cluster until
 # the CloudFormation api supports it, etc.)
 class DominoAwsConfigurator:
-    def __init__(
-        self, scope: cdk.Construct, eks_cluster: eks.Cluster, vpc: ec2.Vpc, s3_api_statement: iam.PolicyStatement
-    ):
+    def __init__(self, scope: cdk.Construct, eks_cluster: eks.Cluster, vpc: ec2.Vpc):
         self.scope = scope
         self.eks_cluster = eks_cluster
         self.vpc = vpc
-        self.s3_api_statement = s3_api_statement
 
         self.install_calico()
 

--- a/cdk/domino_cdk/aws_configurator.py
+++ b/cdk/domino_cdk/aws_configurator.py
@@ -4,7 +4,6 @@ from re import split as re_split
 
 import aws_cdk.aws_ec2 as ec2
 import aws_cdk.aws_eks as eks
-import aws_cdk.aws_iam as iam
 from aws_cdk import core as cdk
 from requests import get as requests_get
 from yaml import safe_load as yaml_safe_load

--- a/cdk/domino_cdk/config/base.py
+++ b/cdk/domino_cdk/config/base.py
@@ -29,6 +29,8 @@ class DominoCDKConfig:
 
     tags: Dict[str, str] = field_property(default={})
 
+    create_iam_roles_for_service_accounts: bool = False
+
     vpc: VPC = None
     efs: EFS = None
     route53: Route53 = None
@@ -58,6 +60,7 @@ class DominoCDKConfig:
                 aws_region=c.pop("aws_region"),
                 aws_account_id=c.pop("aws_account_id"),
                 tags=c.pop("tags", {}),
+                create_iam_roles_for_service_accounts=False,
                 install=c.pop("install", {}),
                 vpc=VPC.from_0_0_0({**c.pop("vpc"), **{"availability_zones": c.pop("availability_zones", [])}}),
                 efs=EFS.from_0_0_0(c.pop("efs")),
@@ -78,6 +81,7 @@ class DominoCDKConfig:
                 aws_region=c.pop("aws_region"),
                 aws_account_id=c.pop("aws_account_id"),
                 tags=c.pop("tags", {}),
+                create_iam_roles_for_service_accounts=c.pop("create_iam_roles_for_service_accounts", False),
                 install=c.pop("install", {}),
                 vpc=VPC.from_0_0_1(c.pop("vpc")),
                 efs=EFS.from_0_0_0(c.pop("efs")),

--- a/cdk/domino_cdk/config/template.py
+++ b/cdk/domino_cdk/config/template.py
@@ -152,6 +152,7 @@ def config_template(
         aws_region=fill,
         aws_account_id=fill,
         tags={"domino-infrastructure": "true"},
+        create_iam_roles_for_service_accounts=False,
         install=install,
         vpc=vpc,
         efs=efs,

--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -47,7 +47,6 @@ class DominoStack(cdk.Stack):
         )
 
         if cfg.create_iam_roles_for_service_accounts:
-            print("WOW!")
             DominoEksK8sIamRolesProvisioner(self).provision(self.name, self.eks_stack.cluster, self.s3_stack.buckets)
 
         self.efs_stack = DominoEfsProvisioner(

--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -42,7 +42,7 @@ class DominoStack(cdk.Stack):
             self.vpc_stack.bastion_sg,
             self.cfg.route53.zone_ids,
             nest,
-            #
+            # Do not pass list of buckets to Eks provisioner if we are not using S3 access per node
             self.s3_stack.buckets if cfg.create_iam_roles_for_service_accounts is False else [],
         )
 

--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -10,6 +10,9 @@ from domino_cdk.provisioners import (
     DominoS3Provisioner,
     DominoVpcProvisioner,
 )
+from domino_cdk.provisioners.eks.eks_iam_roles_for_k8s import (
+    DominoEksK8sIamRolesProvisioner,
+)
 from domino_cdk.util import DominoCdkUtil
 
 
@@ -39,8 +42,14 @@ class DominoStack(cdk.Stack):
             self.vpc_stack.bastion_sg,
             self.cfg.route53.zone_ids,
             nest,
-            self.s3_stack.buckets,
+            #
+            self.s3_stack.buckets if cfg.create_iam_roles_for_service_accounts is False else [],
         )
+
+        if cfg.create_iam_roles_for_service_accounts:
+            print("WOW!")
+            DominoEksK8sIamRolesProvisioner(self).provision(self.name, self.eks_stack.cluster, self.s3_stack.buckets)
+
         self.efs_stack = DominoEfsProvisioner(
             self,
             "EfsStack",

--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -38,8 +38,8 @@ class DominoStack(cdk.Stack):
             self.vpc_stack.private_subnet_name,
             self.vpc_stack.bastion_sg,
             self.cfg.route53.zone_ids,
-            self.s3_stack.policy,
             nest,
+            self.s3_stack.buckets,
         )
         self.efs_stack = DominoEfsProvisioner(
             self,
@@ -53,9 +53,7 @@ class DominoStack(cdk.Stack):
         # At least until we get the lambda working, this has to live in the eks stack's scope
         # as there is some implicit token used to construct the magically auto-generated kubectl
         # lambda behind the scenes when they are in separate stacks (nested or otehrwise).
-        DominoAwsConfigurator(
-            self.eks_stack.scope, self.eks_stack.cluster, self.vpc_stack.vpc, self.s3_stack.s3_api_statement
-        )
+        DominoAwsConfigurator(self.eks_stack.scope, self.eks_stack.cluster, self.vpc_stack.vpc)
 
         self.generate_outputs()
 

--- a/cdk/domino_cdk/provisioners/eks/__init__.py
+++ b/cdk/domino_cdk/provisioners/eks/__init__.py
@@ -32,9 +32,17 @@ class DominoEksProvisioner:
         eks_version = getattr(eks.KubernetesVersion, f"V{eks_cfg.version.replace('.', '_')}")
 
         self.cluster = DominoEksClusterProvisioner(self.scope).provision(
-            stack_name, eks_version, eks_cfg.private_api, eks_cfg.secrets_encryption_key_arn, vpc, bastion_sg, parent.cfg.tags
+            stack_name,
+            eks_version,
+            eks_cfg.private_api,
+            eks_cfg.secrets_encryption_key_arn,
+            vpc,
+            bastion_sg,
+            parent.cfg.tags,
         )
-        ng_role = DominoEksIamProvisioner(self.scope).provision(stack_name, self.cluster.cluster_name, r53_zone_ids, buckets)
+        ng_role = DominoEksIamProvisioner(self.scope).provision(
+            stack_name, self.cluster.cluster_name, r53_zone_ids, buckets
+        )
         DominoEksNodegroupProvisioner(
             self.scope, self.cluster, ng_role, stack_name, eks_cfg, eks_version, vpc, private_subnet_name, bastion_sg
         )

--- a/cdk/domino_cdk/provisioners/eks/__init__.py
+++ b/cdk/domino_cdk/provisioners/eks/__init__.py
@@ -17,7 +17,7 @@ class DominoEksProvisioner:
         self,
         parent: cdk.Construct,
         construct_id: str,
-        name: str,
+        stack_name: str,
         eks_cfg: config.EKS,
         vpc: ec2.Vpc,
         private_subnet_name: str,
@@ -32,11 +32,11 @@ class DominoEksProvisioner:
         eks_version = getattr(eks.KubernetesVersion, f"V{eks_cfg.version.replace('.', '_')}")
 
         self.cluster = DominoEksClusterProvisioner(self.scope).provision(
-            name, eks_version, eks_cfg.private_api, eks_cfg.secrets_encryption_key_arn, vpc, bastion_sg, parent.cfg.tags
+            stack_name, eks_version, eks_cfg.private_api, eks_cfg.secrets_encryption_key_arn, vpc, bastion_sg, parent.cfg.tags
         )
-        ng_role = DominoEksIamProvisioner(self.scope).provision(name, self.cluster.cluster_name, r53_zone_ids, buckets)
+        ng_role = DominoEksIamProvisioner(self.scope).provision(stack_name, self.cluster.cluster_name, r53_zone_ids, buckets)
         DominoEksNodegroupProvisioner(
-            self.scope, self.cluster, ng_role, name, eks_cfg, eks_version, vpc, private_subnet_name, bastion_sg
+            self.scope, self.cluster, ng_role, stack_name, eks_cfg, eks_version, vpc, private_subnet_name, bastion_sg
         )
 
         cdk.CfnOutput(parent, "eks_cluster_name", value=self.cluster.cluster_name)

--- a/cdk/domino_cdk/provisioners/eks/__init__.py
+++ b/cdk/domino_cdk/provisioners/eks/__init__.py
@@ -9,9 +9,6 @@ from aws_cdk.aws_s3 import Bucket
 from domino_cdk import config
 from domino_cdk.provisioners.eks.eks_cluster import DominoEksClusterProvisioner
 from domino_cdk.provisioners.eks.eks_iam import DominoEksIamProvisioner
-from domino_cdk.provisioners.eks.eks_iam_roles_for_k8s import (
-    DominoEksK8sIamRolesProvisioner,
-)
 from domino_cdk.provisioners.eks.eks_nodegroup import DominoEksNodegroupProvisioner
 
 
@@ -37,11 +34,10 @@ class DominoEksProvisioner:
         self.cluster = DominoEksClusterProvisioner(self.scope).provision(
             name, eks_version, eks_cfg.private_api, eks_cfg.secrets_encryption_key_arn, vpc, bastion_sg, parent.cfg.tags
         )
-        ng_role = DominoEksIamProvisioner(self.scope).provision(name, self.cluster.cluster_name, r53_zone_ids)
+        ng_role = DominoEksIamProvisioner(self.scope).provision(name, self.cluster.cluster_name, r53_zone_ids, buckets)
         DominoEksNodegroupProvisioner(
             self.scope, self.cluster, ng_role, name, eks_cfg, eks_version, vpc, private_subnet_name, bastion_sg
         )
-        DominoEksK8sIamRolesProvisioner(self.scope).provision(name, self.cluster, buckets)
 
         cdk.CfnOutput(parent, "eks_cluster_name", value=self.cluster.cluster_name)
         cdk.CfnOutput(

--- a/cdk/domino_cdk/provisioners/eks/eks_cluster.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_cluster.py
@@ -17,7 +17,7 @@ class DominoEksClusterProvisioner:
 
     def provision(
         self,
-        name: str,
+        stack_name: str,
         eks_version: eks.KubernetesVersion,
         private_api: bool,
         secrets_encryption_key_arn: str,
@@ -29,7 +29,7 @@ class DominoEksClusterProvisioner:
             self.scope,
             "EKSSG",
             vpc=vpc,
-            security_group_name=f"{name}-EKSSG",
+            security_group_name=f"{stack_name}-EKSSG",
             allow_all_outbound=False,
         )
 
@@ -38,8 +38,8 @@ class DominoEksClusterProvisioner:
         else:
             key = Key(
                 self.scope,
-                f"{name}-kubernetes-secrets-envelope-key",
-                alias=f"{name}-kubernetes-secrets-envelope-key",
+                f"{stack_name}-kubernetes-secrets-envelope-key",
+                alias=f"{stack_name}-kubernetes-secrets-envelope-key",
                 removal_policy=cdk.RemovalPolicy.DESTROY,
                 enable_key_rotation=True,
             )
@@ -47,7 +47,7 @@ class DominoEksClusterProvisioner:
         cluster = eks.Cluster(
             self.scope,
             "eks",
-            cluster_name=name,
+            cluster_name=stack_name,
             vpc=vpc,
             endpoint_access=eks.EndpointAccess.PRIVATE if private_api else None,
             vpc_subnets=[ec2.SubnetType.PRIVATE],

--- a/cdk/domino_cdk/provisioners/eks/eks_iam.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam.py
@@ -123,7 +123,7 @@ class DominoEksIamProvisioner:
                         "s3:ListMultipartUploadParts",
                         "s3:AbortMultipartUpload",
                     ],
-                    resources={f"{b.bucket_arn}*" for b in buckets.values()},
+                    resources=[f"{b.bucket_arn}*" for b in buckets.values()],
                 ),
             ],
         )

--- a/cdk/domino_cdk/provisioners/eks/eks_iam.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam.py
@@ -69,26 +69,7 @@ class DominoEksIamProvisioner:
         ]
 
         if r53_zone_ids:
-            managed_policies.append(
-                iam.ManagedPolicy(
-                    self.scope,
-                    "route53",
-                    managed_policy_name=f"{stack_name}-route53",
-                    statements=[
-                        iam.PolicyStatement(
-                            actions=["route53:ListHostedZones"],
-                            resources=["*"],
-                        ),
-                        iam.PolicyStatement(
-                            actions=[
-                                "route53:ChangeResourceRecordSets",
-                                "route53:ListResourceRecordSets",
-                            ],
-                            resources=[f"arn:aws:route53:::hostedzone/{zone_id}" for zone_id in r53_zone_ids],
-                        ),
-                    ],
-                )
-            )
+            managed_policies.append(self.provision_r53_policy(stack_name, r53_zone_ids))
 
         if buckets:
             managed_policies.append(self.provision_node_s3_iam_policy(stack_name, buckets))
@@ -101,11 +82,31 @@ class DominoEksIamProvisioner:
             managed_policies=managed_policies,
         )
 
-    def provision_node_s3_iam_policy(self, name: str, buckets: Dict[str, Bucket]) -> iam.ManagedPolicy:
+    def provision_r53_policy(self, stack_name: str, r53_zone_ids: List[str]):
+        return iam.ManagedPolicy(
+            self.scope,
+            "route53",
+            managed_policy_name=f"{stack_name}-route53",
+            statements=[
+                iam.PolicyStatement(
+                    actions=["route53:ListHostedZones"],
+                    resources=["*"],
+                ),
+                iam.PolicyStatement(
+                    actions=[
+                        "route53:ChangeResourceRecordSets",
+                        "route53:ListResourceRecordSets",
+                    ],
+                    resources=[f"arn:aws:route53:::hostedzone/{zone_id}" for zone_id in r53_zone_ids],
+                ),
+            ],
+        )
+
+    def provision_node_s3_iam_policy(self, stack_name: str, buckets: Dict[str, Bucket]) -> iam.ManagedPolicy:
         return iam.ManagedPolicy(
             self.scope,
             "S3",
-            managed_policy_name=f"{name}-S3",
+            managed_policy_name=f"{stack_name}-S3",
             statements=[
                 iam.PolicyStatement(
                     actions=[

--- a/cdk/domino_cdk/provisioners/eks/eks_iam.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam.py
@@ -1,7 +1,8 @@
-from typing import List
+from typing import List, Dict
 
 import aws_cdk.aws_iam as iam
 from aws_cdk import core as cdk
+from aws_cdk.aws_s3 import Bucket
 
 
 class DominoEksIamProvisioner:
@@ -11,7 +12,7 @@ class DominoEksIamProvisioner:
     ) -> None:
         self.scope = scope
 
-    def provision(self, name: str, cluster_name: str, r53_zone_ids: List[str]):
+    def provision(self, stack_name: str, cluster_name: str, r53_zone_ids: List[str], buckets: Dict[str, Bucket]):
         asg_group_statement = iam.PolicyStatement(
             actions=[
                 "autoscaling:DescribeAutoScalingInstances",
@@ -25,7 +26,7 @@ class DominoEksIamProvisioner:
         autoscaler_policy = iam.ManagedPolicy(
             self.scope,
             "autoscaler",
-            managed_policy_name=f"{name}-autoscaler",
+            managed_policy_name=f"{stack_name}-autoscaler",
             statements=[
                 iam.PolicyStatement(
                     actions=[
@@ -40,30 +41,10 @@ class DominoEksIamProvisioner:
             ],
         )
 
-        if r53_zone_ids:
-            route53_policy = iam.ManagedPolicy(
-                self.scope,
-                "route53",
-                managed_policy_name=f"{name}-route53",
-                statements=[
-                    iam.PolicyStatement(
-                        actions=["route53:ListHostedZones"],
-                        resources=["*"],
-                    ),
-                    iam.PolicyStatement(
-                        actions=[
-                            "route53:ChangeResourceRecordSets",
-                            "route53:ListResourceRecordSets",
-                        ],
-                        resources=[f"arn:aws:route53:::hostedzone/{zone_id}" for zone_id in r53_zone_ids],
-                    ),
-                ],
-            )
-
         ecr_policy = iam.ManagedPolicy(
             self.scope,
-            f"{name}-DominoEcrRestricted",
-            managed_policy_name=f"{name}-DominoEcrRestricted",
+            f"{stack_name}-DominoEcrRestricted",
+            managed_policy_name=f"{stack_name}-DominoEcrRestricted",
             statements=[
                 iam.PolicyStatement(
                     effect=iam.Effect.DENY,
@@ -72,7 +53,7 @@ class DominoEksIamProvisioner:
                         "ecr:BatchGetImage",
                         "ecr:GetDownloadUrlForLayer",
                     ],
-                    conditions={"StringNotEqualsIfExists": {"ecr:ResourceTag/domino-deploy-id": name}},
+                    conditions={"StringNotEqualsIfExists": {"ecr:ResourceTag/domino-deploy-id": stack_name}},
                     resources=[f"arn:aws:ecr:*:{self.scope.account}:*"],
                 ),
             ],
@@ -86,13 +67,66 @@ class DominoEksIamProvisioner:
             iam.ManagedPolicy.from_aws_managed_policy_name('AmazonEKS_CNI_Policy'),
             iam.ManagedPolicy.from_aws_managed_policy_name('AmazonSSMManagedInstanceCore'),
         ]
+
         if r53_zone_ids:
-            managed_policies.append(route53_policy)
+            managed_policies.append(
+                iam.ManagedPolicy(
+                    self.scope,
+                    "route53",
+                    managed_policy_name=f"{stack_name}-route53",
+                    statements=[
+                        iam.PolicyStatement(
+                            actions=["route53:ListHostedZones"],
+                            resources=["*"],
+                        ),
+                        iam.PolicyStatement(
+                            actions=[
+                                "route53:ChangeResourceRecordSets",
+                                "route53:ListResourceRecordSets",
+                            ],
+                            resources=[f"arn:aws:route53:::hostedzone/{zone_id}" for zone_id in r53_zone_ids],
+                        ),
+                    ],
+                )
+            )
+
+        if buckets:
+            managed_policies.append(
+                self.provision_node_s3_iam_policy(stack_name, buckets)
+            )
+
 
         return iam.Role(
             self.scope,
-            f'{name}-NG',
-            role_name=f"{name}-NG",
+            f'{stack_name}-NG',
+            role_name=f"{stack_name}-NG",
             assumed_by=iam.ServicePrincipal('ec2.amazonaws.com'),
             managed_policies=managed_policies,
+        )
+
+    def provision_node_s3_iam_policy(self, name: str, buckets: Dict[str, Bucket]) -> iam.ManagedPolicy:
+        return iam.ManagedPolicy(
+            self.scope,
+            "S3",
+            managed_policy_name=f"{name}-S3",
+            statements=[
+                iam.PolicyStatement(
+                    actions=[
+                        "s3:ListBucket",
+                        "s3:GetBucketLocation",
+                        "s3:ListBucketMultipartUploads",
+                    ],
+                    resources=["*"],
+                ),
+                iam.PolicyStatement(
+                    actions=[
+                        "s3:PutObject",
+                        "s3:GetObject",
+                        "s3:DeleteObject",
+                        "s3:ListMultipartUploadParts",
+                        "s3:AbortMultipartUpload",
+                    ],
+                    resources={f"{b.bucket_arn}*" for b in buckets.values()},
+                ),
+            ],
         )

--- a/cdk/domino_cdk/provisioners/eks/eks_iam.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import Dict, List
 
 import aws_cdk.aws_iam as iam
 from aws_cdk import core as cdk
@@ -91,10 +91,7 @@ class DominoEksIamProvisioner:
             )
 
         if buckets:
-            managed_policies.append(
-                self.provision_node_s3_iam_policy(stack_name, buckets)
-            )
-
+            managed_policies.append(self.provision_node_s3_iam_policy(stack_name, buckets))
 
         return iam.Role(
             self.scope,

--- a/cdk/domino_cdk/provisioners/eks/eks_iam_roles_for_k8s.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam_roles_for_k8s.py
@@ -61,16 +61,16 @@ ecr_write_permisions = [
 # Roles. The roles are the collection of the policies.
 roles = {
     # E.g. nucleus needs this role
-    "write_blobs_read_logs": [
+    "blobs-write--logs-read": [
         "blobs:write",
         "logs:read",
     ],
     # E.g. executor needs this role
-    "write_blobs": [
+    "blobs-write": [
         "blobs:write",
     ],
     # E.g. builder needs this role
-    "write_images": [
+    "images-write": [
         "ecr:write",
     ],
 }

--- a/cdk/domino_cdk/provisioners/eks/eks_iam_roles_for_k8s.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam_roles_for_k8s.py
@@ -1,0 +1,176 @@
+from typing import Dict, List
+
+import aws_cdk.aws_eks as eks
+import aws_cdk.aws_iam as iam
+from aws_cdk import core as cdk
+from aws_cdk.aws_s3 import Bucket
+
+# Permission groups
+
+s3_write_permissions = [
+    "s3:PutObject",
+    "s3:DeleteObject",
+    "s3:ListMultipartUploadParts",
+    "s3:AbortMultipartUpload",
+]
+
+s3_read_permissions = [
+    "s3:GetObject",
+]
+
+ecr_policies = {
+    "ecr_read_write_permissions": [
+        "ecr:PutImageTagMutability",
+        "ecr:StartImageScan",
+        "ecr:ListTagsForResource",
+        "ecr:UploadLayerPart",
+        "ecr:BatchDeleteImage",
+        "ecr:ListImages",
+        "ecr:DeleteRepository",
+        "ecr:CompleteLayerUpload",
+        "ecr:TagResource",
+        "ecr:DescribeRepositories",
+        "ecr:DeleteRepositoryPolicy",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:ReplicateImage",
+        "ecr:GetLifecyclePolicy",
+        "ecr:PutLifecyclePolicy",
+        "ecr:DescribeImageScanFindings",
+        "ecr:GetLifecyclePolicyPreview",
+        "ecr:CreateRepository",
+        "ecr:PutImageScanningConfiguration",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:DeleteLifecyclePolicy",
+        "ecr:PutImage",
+        "ecr:UntagResource",
+        "ecr:BatchGetImage",
+        "ecr:DescribeImages",
+        "ecr:StartLifecyclePolicyPreview",
+        "ecr:InitiateLayerUpload",
+        "ecr:GetRepositoryPolicy",
+    ]
+}
+
+s3_policies = {
+    "write_blobs_read_logs": {
+        "blobs": s3_read_permissions + s3_write_permissions,
+        "logs": s3_read_permissions,
+    },
+    "write_blobs": {
+        "blobs": s3_read_permissions + s3_write_permissions,
+    },
+    "read_logs": {
+        "logs": s3_read_permissions,
+    },
+    "read_blobs": {
+        "blobs": s3_read_permissions,
+    },
+}
+
+
+# Roles
+roles = {
+    "nucleus": [
+        "write_blobs_read_logs",
+    ],
+    "executor": [
+        "write_blobs",
+    ],
+    "builder": [
+        "ecr_read_write_permissions",
+    ],
+}
+
+
+class DominoEksK8sIamRolesProvisioner:
+    def __init__(
+        self,
+        scope: cdk.Construct,
+    ) -> None:
+        self.scope = scope
+
+    def print_children(self, construct):
+        print(construct.node.path, construct.to_string())
+        for c in construct.node.children:
+            self.print_children(c)
+
+    def provision(self, stack_name: str, cluster: eks.Cluster, buckets: Dict[str, Bucket]):
+        # Create dummy service account just to make EKS to do heavy listing of creating OIDC
+        # TODO: perform associate_iam_oidc_provider by lambda so we do  not create dummy stuff
+        sa = eks.ServiceAccount(cluster, "dummy", cluster=cluster, name="dummy")
+        # Then we copy policy doc
+        statement_json = sa.role.assume_role_policy.to_json()['Statement'][0]
+        del statement_json['Condition']['StringEquals']
+        logical_id = self.scope.get_logical_id(
+            # Warning! Magic! We go two levels deep because child OpenIdConnectProvider is type Construct but
+            # logical_id belongs to type CfnElement, which is linked from below like this.
+            cluster.node.find_child("OpenIdConnectProvider").node.default_child.node.default_child
+        )
+        fn = cdk.Fn.select(
+            1,
+            cdk.Fn.split(
+                ":oidc-provider/",
+                cdk.Fn.ref(logical_id),
+            ),
+        )
+        statement_json['Condition']['StringLike'] = cdk.CfnJson(
+            self.scope, "OidcJson", value={f"{fn}:aud": "sts.amazonaws.com", f"{fn}:sub": "system:serviceaccount:*"}
+        )
+        managed_policies = {}
+        for name, cfg in ecr_policies.items():
+            managed_policies[name] = self.create_ecr_policy(stack_name, name, cfg)
+        for name, cfg in s3_policies.items():
+            managed_policies[name] = self.create_s3_policy(name, cfg, buckets)
+
+        for name, policy_list in roles.items():
+            iam_role = iam.Role(
+                self.scope,
+                f"{stack_name}-IAM-role-for-k8s-{name}",
+                # Undesired side effect of this: additional statement is created to trust this principal.
+                # Because Role constructor mandates principal and creates assume_role_policy
+                # with this statement. And later we cannot neither replace assume_role_policy nor remove this statement.
+                # Potentially we can avoid this by using CnfRole but no examples exist. A guesswork can take a week.
+                assumed_by=iam.ServicePrincipal('eks.amazonaws.com'),
+                role_name=f"{stack_name}-IAM-role-for-k8s-{name}",
+            )
+            iam_role.assume_role_policy.add_statements(iam.PolicyStatement.from_json(statement_json))
+            for policy_name in policy_list:
+                iam_role.add_managed_policy(managed_policies[policy_name])
+
+    def create_ecr_policy(self, stack_name: str, policy_name: str, actions: List[str]):
+        return iam.ManagedPolicy(
+            self.scope,
+            f"{stack_name}-{policy_name}-ECR",
+            managed_policy_name=f"{stack_name}-{policy_name}-ECR",
+            statements=[
+                iam.PolicyStatement(
+                    effect=iam.Effect.ALLOW,
+                    actions=actions,
+                    resources=["*"],
+                ),
+                iam.PolicyStatement(
+                    effect=iam.Effect.DENY,
+                    actions=["ecr:*"],
+                    conditions={"StringNotEqualsIfExists": {"ecr:ResourceTag/domino-deploy-id": stack_name}},
+                    resources=[f"arn:aws:ecr:*:{self.scope.account}:*"],
+                ),
+            ],
+        )
+
+    def create_s3_policy(self, policy_name: str, cfg: Dict[str, List[str]], buckets: Dict[str, Bucket]):
+        statements = []
+        for bucket_name, actions in cfg.items():
+            if bucket_name not in buckets:
+                raise Exception(f'Unknown bucket "{bucket_name}" in policy "{policy_name}"')
+            statements.append(
+                iam.PolicyStatement(
+                    actions=actions,
+                    resources=[f"{buckets[bucket_name].bucket_arn}*"],
+                ),
+            )
+        return iam.ManagedPolicy(
+            self.scope,
+            f"{policy_name}-S3",
+            managed_policy_name=f"{policy_name}-S3",
+            statements=statements,
+        )

--- a/cdk/domino_cdk/provisioners/eks/eks_iam_roles_for_k8s.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam_roles_for_k8s.py
@@ -26,56 +26,49 @@ s3_read_permissions = [
 ]
 
 ecr_write_permisions = [
-        "ecr:PutImageTagMutability",
-        "ecr:StartImageScan",
-        "ecr:ListTagsForResource",
-        "ecr:UploadLayerPart",
-        "ecr:BatchDeleteImage",
-        "ecr:ListImages",
-        "ecr:DeleteRepository",
-        "ecr:CompleteLayerUpload",
-        "ecr:TagResource",
-        "ecr:DescribeRepositories",
-        "ecr:DeleteRepositoryPolicy",
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:ReplicateImage",
-        "ecr:GetLifecyclePolicy",
-        "ecr:PutLifecyclePolicy",
-        "ecr:DescribeImageScanFindings",
-        "ecr:GetLifecyclePolicyPreview",
-        "ecr:CreateRepository",
-        "ecr:PutImageScanningConfiguration",
-        "ecr:GetDownloadUrlForLayer",
-        "ecr:DeleteLifecyclePolicy",
-        "ecr:PutImage",
-        "ecr:UntagResource",
-        "ecr:BatchGetImage",
-        "ecr:DescribeImages",
-        "ecr:StartLifecyclePolicyPreview",
-        "ecr:InitiateLayerUpload",
-        "ecr:GetRepositoryPolicy",
-    ]
+    "ecr:PutImageTagMutability",
+    "ecr:StartImageScan",
+    "ecr:ListTagsForResource",
+    "ecr:UploadLayerPart",
+    "ecr:BatchDeleteImage",
+    "ecr:ListImages",
+    "ecr:DeleteRepository",
+    "ecr:CompleteLayerUpload",
+    "ecr:TagResource",
+    "ecr:DescribeRepositories",
+    "ecr:DeleteRepositoryPolicy",
+    "ecr:BatchCheckLayerAvailability",
+    "ecr:ReplicateImage",
+    "ecr:GetLifecyclePolicy",
+    "ecr:PutLifecyclePolicy",
+    "ecr:DescribeImageScanFindings",
+    "ecr:GetLifecyclePolicyPreview",
+    "ecr:CreateRepository",
+    "ecr:PutImageScanningConfiguration",
+    "ecr:GetDownloadUrlForLayer",
+    "ecr:DeleteLifecyclePolicy",
+    "ecr:PutImage",
+    "ecr:UntagResource",
+    "ecr:BatchGetImage",
+    "ecr:DescribeImages",
+    "ecr:StartLifecyclePolicyPreview",
+    "ecr:InitiateLayerUpload",
+    "ecr:GetRepositoryPolicy",
+]
 
 # The bucket policies are auto-generated from the bucket list with the names write-name, read-name. E.g. write_blobs
 
 # Roles. The roles are the collection of the policies.
 roles = {
     # E.g. nucleus needs this role
-    "blobs-write--logs-read":
-        {
-            "blobs": "write" ,
-            "logs": "read",
-        },
+    "blobs-write--logs-read": {
+        "blobs": "write",
+        "logs": "read",
+    },
     # E.g. executor needs this role
-    "blobs-write":
-        {
-            "blobs": "write"
-        },
+    "blobs-write": {"blobs": "write"},
     # E.g. builder needs this role
-    "images-write":
-        {
-            "ecr": "write"
-        },
+    "images-write": {"ecr": "write"},
 }
 
 
@@ -109,7 +102,7 @@ class DominoEksK8sIamRolesProvisioner:
             self.scope, "OidcJson", value={f"{fn}:aud": "sts.amazonaws.com", f"{fn}:sub": "system:serviceaccount:*"}
         )
         managed_policies = {}
-        managed_policies["ecr"] = { "write": self.create_ecr_policy(stack_name, "ecr-write", ecr_write_permisions) }
+        managed_policies["ecr"] = {"write": self.create_ecr_policy(stack_name, "ecr-write", ecr_write_permisions)}
 
         managed_policies.update(self.create_s3_policies(stack_name, buckets))
 
@@ -133,7 +126,7 @@ class DominoEksK8sIamRolesProvisioner:
         return iam.ManagedPolicy(
             self.scope,
             external_policy_name,
-            managed_policy_name=external_policy_name    ,
+            managed_policy_name=external_policy_name,
             statements=[
                 iam.PolicyStatement(
                     effect=iam.Effect.ALLOW,
@@ -168,7 +161,7 @@ class DominoEksK8sIamRolesProvisioner:
                     iam.PolicyStatement(
                         actions=s3_read_permissions,
                         resources=[f"{bucket.bucket_arn}*"],
-                    )
+                    ),
                 ],
             )
             # Write
@@ -185,7 +178,7 @@ class DominoEksK8sIamRolesProvisioner:
                     iam.PolicyStatement(
                         actions=s3_write_permissions,
                         resources=[f"{bucket.bucket_arn}*"],
-                    )
+                    ),
                 ],
             )
         return policies

--- a/cdk/domino_cdk/provisioners/eks/eks_iam_roles_for_k8s.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam_roles_for_k8s.py
@@ -19,7 +19,7 @@ s3_read_permissions = [
 ]
 
 ecr_policies = {
-    "ecr_read_write_permissions": [
+    "ecr_read_write_policy": [
         "ecr:PutImageTagMutability",
         "ecr:StartImageScan",
         "ecr:ListTagsForResource",
@@ -50,23 +50,6 @@ ecr_policies = {
         "ecr:GetRepositoryPolicy",
     ]
 }
-
-s3_policies = {
-    "write_blobs_read_logs": {
-        "blobs": s3_read_permissions + s3_write_permissions,
-        "logs": s3_read_permissions,
-    },
-    "write_blobs": {
-        "blobs": s3_read_permissions + s3_write_permissions,
-    },
-    "read_logs": {
-        "logs": s3_read_permissions,
-    },
-    "read_blobs": {
-        "blobs": s3_read_permissions,
-    },
-}
-
 
 # Roles
 roles = {

--- a/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
@@ -15,7 +15,7 @@ class DominoEksNodegroupProvisioner:
         scope: cdk.Construct,
         cluster: eks.Cluster,
         ng_role: iam.Role,
-        name: str,
+        stack_name: str,
         eks_cfg: config.EKS,
         eks_version: eks.KubernetesVersion,
         vpc: ec2.Vpc,
@@ -25,7 +25,7 @@ class DominoEksNodegroupProvisioner:
         self.scope = scope
         self.cluster = cluster
         self.ng_role = ng_role
-        self.name = name
+        self.stack_name = stack_name
         self.eks_cfg = eks_cfg
         self.eks_version = eks_version
         self.vpc = vpc
@@ -60,7 +60,7 @@ class DominoEksNodegroupProvisioner:
             self.cluster,
             f"LaunchTemplate{name}",
             key_name=ng.key_name,
-            launch_template_name=f"{self.name}-{name}",
+            launch_template_name=f"{self.stack_name}-{name}",
             block_devices=[
                 ec2.BlockDevice(
                     device_name="/dev/xvda",
@@ -77,8 +77,8 @@ class DominoEksNodegroupProvisioner:
 
         for i, az in enumerate(self.vpc.availability_zones[:max_nodegroup_azs]):
             self.cluster.add_nodegroup_capacity(
-                f"{self.name}-{name}-{i}",
-                nodegroup_name=f"{self.name}-{name}-{az}",
+                f"{self.stack_name}-{name}-{i}",
+                nodegroup_name=f"{self.stack_name}-{name}-{az}",
                 capacity_type=eks.CapacityType.SPOT if ng.spot else eks.CapacityType.ON_DEMAND,
                 min_size=ng.min_size,
                 max_size=ng.max_size,
@@ -112,7 +112,7 @@ class DominoEksNodegroupProvisioner:
                 self.scope,
                 "UnmanagedSG",
                 vpc=self.vpc,
-                security_group_name=f"{self.name}-sharedNodeSG",
+                security_group_name=f"{self.stack_name}-sharedNodeSG",
                 allow_all_outbound=False,
             )
 
@@ -130,10 +130,10 @@ class DominoEksNodegroupProvisioner:
         scope = cdk.Construct(self.scope, f"UnmanagedNodeGroup{name}")
         cfn_lt = None
         for i, az in enumerate(self.vpc.availability_zones[:max_nodegroup_azs]):
-            indexed_name = f"{self.name}-{name}-{az}"
+            indexed_name = f"{self.stack_name}-{name}-{az}"
             asg = aws_autoscaling.AutoScalingGroup(
                 scope,
-                f"{self.name}-{name}-{i}",
+                f"{self.stack_name}-{name}-{i}",
                 auto_scaling_group_name=indexed_name,
                 instance_type=ec2.InstanceType(ng.instance_types[0]),
                 machine_image=machine_image,
@@ -264,7 +264,7 @@ class DominoEksNodegroupProvisioner:
                                 ud,
                                 {
                                     "NodegroupName": name,
-                                    "StackName": self.name,
+                                    "StackName": self.stack_name,
                                     "ClusterName": self.cluster.cluster_name,
                                 },
                             ),

--- a/cdk/domino_cdk/provisioners/s3.py
+++ b/cdk/domino_cdk/provisioners/s3.py
@@ -12,18 +12,7 @@ class DominoS3Provisioner:
     def __init__(self, parent: cdk.Construct, construct_id: str, name: str, s3: List[config.S3], nest: bool, **kwargs):
         self.parent = parent
         self.scope = cdk.NestedStack(self.parent, construct_id, **kwargs) if nest else self.parent
-
-        self.s3_api_statement = iam.PolicyStatement(
-            actions=[
-                "s3:PutObject",
-                "s3:GetObject",
-                "s3:DeleteObject",
-                "s3:ListMultipartUploadParts",
-                "s3:AbortMultipartUpload",
-            ]
-        )
         self.provision_buckets(name, s3)
-        self.provision_iam_policy(name)
 
     def provision_buckets(self, name: str, s3: List[config.S3]):
         self.buckets = {}
@@ -72,23 +61,5 @@ class DominoS3Provisioner:
                     conditions={"Null": {"s3:x-amz-server-side-encryption": "true"}},
                 )
             )
-            self.s3_api_statement.add_resources(f"{self.buckets[bucket].bucket_arn}*")
-            cdk.CfnOutput(self.parent, f"{bucket}-output", value=self.buckets[bucket].bucket_name)
 
-    def provision_iam_policy(self, name: str):
-        self.policy = iam.ManagedPolicy(
-            self.scope,
-            "S3",
-            managed_policy_name=f"{name}-S3",
-            statements=[
-                iam.PolicyStatement(
-                    actions=[
-                        "s3:ListBucket",
-                        "s3:GetBucketLocation",
-                        "s3:ListBucketMultipartUploads",
-                    ],
-                    resources=["*"],
-                ),
-                self.s3_api_statement,
-            ],
-        )
+            cdk.CfnOutput(self.parent, f"{bucket}-output", value=self.buckets[bucket].bucket_name)

--- a/cdk/domino_cdk/provisioners/s3.py
+++ b/cdk/domino_cdk/provisioners/s3.py
@@ -14,7 +14,7 @@ class DominoS3Provisioner:
         self.scope = cdk.NestedStack(self.parent, construct_id, **kwargs) if nest else self.parent
         self.provision_buckets(name, s3)
 
-    def provision_buckets(self, name: str, s3: List[config.S3]):
+    def provision_buckets(self, stack_name: str, s3: List[config.S3]):
         self.buckets = {}
         for bucket, attrs in s3.buckets.items():
             use_sse_kms_key = False
@@ -25,7 +25,7 @@ class DominoS3Provisioner:
             self.buckets[bucket] = Bucket(
                 self.scope,
                 bucket,
-                bucket_name=f"{name}-{bucket}",
+                bucket_name=f"{stack_name}-{bucket}",
                 auto_delete_objects=attrs.auto_delete_objects and attrs.removal_policy_destroy,
                 removal_policy=cdk.RemovalPolicy.DESTROY if attrs.removal_policy_destroy else cdk.RemovalPolicy.RETAIN,
                 enforce_ssl=True,

--- a/cdk/domino_cdk/provisioners/vpc.py
+++ b/cdk/domino_cdk/provisioners/vpc.py
@@ -18,9 +18,9 @@ class DominoVpcProvisioner:
         self.provision_vpc(name, vpc)
         self.bastion_sg = self.provision_bastion(name, vpc.bastion)
 
-    def provision_vpc(self, name: str, vpc: config.VPC):
-        self.public_subnet_name = f"{name}-public"
-        self.private_subnet_name = f"{name}-private"
+    def provision_vpc(self, stack_name: str, vpc: config.VPC):
+        self.public_subnet_name = f"{stack_name}-public"
+        self.private_subnet_name = f"{stack_name}-private"
         if not vpc.create:
             self.vpc = ec2.Vpc.from_lookup("Vpc", vpc_id=vpc.id)
             return
@@ -48,7 +48,7 @@ class DominoVpcProvisioner:
             },
             nat_gateway_provider=nat_provider,
         )
-        cdk.Tags.of(self.vpc).add("Name", name)
+        cdk.Tags.of(self.vpc).add("Name", stack_name)
         cdk.CfnOutput(self.parent, "vpc-output", value=self.vpc.vpc_cidr_block)
 
         # ripped off this: https://github.com/aws/aws-cdk/issues/9573
@@ -58,7 +58,7 @@ class DominoVpcProvisioner:
             pod_subnet = ec2.PrivateSubnet(
                 self.scope,
                 # this can't be okay
-                f"{name}-pod-{c}",  # Can't use parameter/token in this name
+                f"{stack_name}-pod-{c}",  # Can't use parameter/token in this name
                 vpc_id=self.vpc.vpc_id,
                 availability_zone=az,
                 cidr_block=f"100.64.{c}.0/18",


### PR DESCRIPTION
We configure IAM roles to associate with service accounts in k8s. 

We have a switch to choose between the node level roles and service level nodes.

ECR permissions for the nodes are changed to the recommended for the worker nodes.

See code comments for more details.