### PR TITLE
PLAT-2142: Terraform support for multiple deploy policies

### DIFF
--- a/cdk/domino_cdk/config/iam.py
+++ b/cdk/domino_cdk/config/iam.py
@@ -131,6 +131,7 @@ def generate_iam(stack_name: str, aws_account_id: str, manual: bool = False, use
         "Action": [
             "states:CreateStateMachine",
             "states:DeleteStateMachine",
+            "states:DescribeStateMachine",
             "states:TagResource",
             "states:UntagResource",
             "states:UpdateStateMachine",

--- a/cdk/domino_cdk/config/iam.py
+++ b/cdk/domino_cdk/config/iam.py
@@ -323,6 +323,7 @@ def generate_iam(stack_name: str, aws_account_id: str, manual: bool = False, use
             "elasticfilesystem:TagResource",
             "elasticfilesystem:UntagResource",
             "iam:GetRole",
+            "iam:GetRolePolicy",
         ],
         **do_cf(),
         "Resource": "*",

--- a/cdk/domino_cdk/config/iam.py
+++ b/cdk/domino_cdk/config/iam.py
@@ -244,6 +244,7 @@ def generate_iam(stack_name: str, aws_account_id: str, manual: bool = False, use
             "kms:RetireGrant",
             "kms:ScheduleKeyDeletion",
             "kms:TagResource",
+            "kms:UpdateAlias",
         ],
         **from_cf_condition,
         "Resource": "*",

--- a/cdk/domino_cdk/util.py
+++ b/cdk/domino_cdk/util.py
@@ -5,6 +5,7 @@ from os.path import basename, isfile
 from os.path import join as path_join
 from subprocess import run
 from time import time
+from typing import List
 from urllib.parse import urlparse
 
 
@@ -63,7 +64,7 @@ class DominoCdkUtil:
         output_dir: str,
         disable_random_templates: bool = False,
         iam_role_arn: str = "",
-        iam_policy_path: str = "",
+        iam_policy_paths: List[str] = None,
     ):
         cfg = cls.load_manifest(path_join(asset_dir, "manifest.json"))
         stack_name = cfg["name"]
@@ -102,7 +103,7 @@ class DominoCdkUtil:
                     "aws_region": aws_region,
                     "name": stack_name,
                     "iam_role_arn": iam_role_arn,
-                    "iam_policy_path": iam_policy_path,
+                    "iam_policy_paths": iam_policy_paths,
                     "parameters": asset_parameters,
                     "template_filename": basename(template_filename),
                     "output_dir": output_dir,

--- a/cdk/util.py
+++ b/cdk/util.py
@@ -13,7 +13,7 @@ from domino_cdk.config.template import config_template
 from domino_cdk.util import DominoCdkUtil
 
 DEFAULT_TF_MODULE_PATH = (
-    "https://github.com/dominodatalab/cdk-cf-eks/releases/download/v0.0.1rc1/domino-cdk-terraform-0.0.1rc1.tar.gz"
+    "https://github.com/dominodatalab/cdk-cf-eks/releases/download/v0.0.1rc2/domino-cdk-terraform-0.0.1-rc2.tar.gz"
 )
 
 
@@ -124,8 +124,9 @@ def parse_args():
     )
     tf_bootstrap_parser.add_argument(
         "--iam-policy-path",
-        help="IAM policy file to provision as role and assign to CloudFormation stack (optional)",
-        default=None,
+        help="IAM policy file(s) to provision as role and assign to CloudFormation stack (optional, can be specified multiple times)",
+        action="append",
+        default=[],
     )
     tf_bootstrap_parser.set_defaults(func=generate_terraform_bootstrap)
 

--- a/cdk/util.py
+++ b/cdk/util.py
@@ -124,7 +124,7 @@ def parse_args():
     )
     tf_bootstrap_parser.add_argument(
         "--iam-policy-path",
-        help="IAM policy file(s) to provision as role and assign to CloudFormation stack (optional, can be specified multiple times)",
+        help="IAM policy file(s) to provision and attach to role and assign to CloudFormation stack. Can be specified multiple times for multiple policies.  (optional)",
         action="append",
         default=[],
     )

--- a/terraform/cloudformation.tf
+++ b/terraform/cloudformation.tf
@@ -6,7 +6,7 @@ resource "aws_cloudformation_stack" "cdk_stack" {
   ]
   parameters         = var.parameters
   template_url       = "https://${aws_s3_bucket.cf_asset_bucket.bucket_regional_domain_name}/${var.template_filename}"
-  iam_role_arn       = var.iam_policy_path != "" ? aws_iam_role.deployment[0].arn : var.iam_role_arn
+  iam_role_arn       = length(var.iam_policy_paths) != 0 ? aws_iam_role.deployment[0].arn : var.iam_role_arn
   depends_on         = [aws_s3_bucket_object.assets]
   timeout_in_minutes = var.cloudformation_timeout_in_minutes
 

--- a/terraform/cloudformation.tf
+++ b/terraform/cloudformation.tf
@@ -32,7 +32,7 @@ resource "local_file" "agent_template" {
 
 resource "null_resource" "kubeconfig" {
   provisioner "local-exec" {
-    command = "${lookup(aws_cloudformation_stack.cdk_stack.outputs, "ekskubeconfigcmd", "")} --kubeconfig ${abspath("${var.output_dir}/kubeconfig")}"
+    command = "${lookup(aws_cloudformation_stack.cdk_stack.outputs, "ekskubeconfigcmd", "")} --kubeconfig ${abspath("${var.output_dir}/kubeconfig")} && chmod 600 ${abspath("${var.output_dir}/kubeconfig")}"
   }
 
   depends_on = [aws_cloudformation_stack.cdk_stack]

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,15 +1,15 @@
 resource "aws_iam_policy" "deployment" {
-    count = var.iam_policy_path != "" ? 1: 0
+    count = length(var.iam_policy_paths)
 
-    name = "${var.name}-deployment-policy"
+    name = "${var.name}-deployment-policy-${count.index}"
 
-    policy = file(var.iam_policy_path)
+    policy = file(var.iam_policy_paths[count.index])
 
     tags = var.tags
 }
 
 resource "aws_iam_role" "deployment" {
-    count = var.iam_policy_path != "" ? 1: 0
+    count = length(var.iam_policy_paths) != 0 ? 1: 0
 
     name = "${var.name}-deployment-role"
 
@@ -27,9 +27,7 @@ resource "aws_iam_role" "deployment" {
         ]
     })
 
-    managed_policy_arns = [
-        aws_iam_policy.deployment[0].arn
-    ]
+    managed_policy_arns = aws_iam_policy.deployment[*].arn
 
     provisioner "local-exec" {
       command = "sleep 15"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -39,10 +39,9 @@ variable "iam_role_arn" {
   default     = ""
 }
 
-variable "iam_policy_path" {
-  type        = string
-  description = "IAM policy to provision and use for deployment"
-  default     = ""
+variable "iam_policy_paths" {
+  type        = list
+  description = "IAM policies to provision and use for deployment role"
 }
 
 variable "cloudformation_timeout_in_minutes" {


### PR DESCRIPTION
Split the IAM policy in two at the last minute to reduce the chances of running into size restrictions during #24.

This PR adds support on the terraform module/terraform-config-generator portion for these multiple policies. Required for deployer integration. 