### PR TITLE
Save config as stack output + use ruamel for agent template output

### DIFF
--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import core as cdk
-from yaml import dump as yaml_dump
 
 from domino_cdk.agent import generate_install_config
 from domino_cdk.aws_configurator import DominoAwsConfigurator
@@ -107,4 +106,5 @@ class DominoStack(cdk.Stack):
 
         merged_cfg = DominoCdkUtil.deep_merge(agent_cfg, self.cfg.install)
 
-        cdk.CfnOutput(self, "agent_config", value=yaml_dump(merged_cfg))
+        cdk.CfnOutput(self, "agent_config", value=DominoCdkUtil.ruamel_dump(merged_cfg))
+        cdk.CfnOutput(self, "cdk_config", value=DominoCdkUtil.ruamel_dump(self.cfg.render(True)))

--- a/cdk/domino_cdk/util.py
+++ b/cdk/domino_cdk/util.py
@@ -1,5 +1,6 @@
 from filecmp import cmp
 from glob import glob
+from io import BytesIO
 from json import loads as json_loads
 from os.path import basename, isfile
 from os.path import join as path_join
@@ -7,6 +8,8 @@ from subprocess import run
 from time import time
 from typing import List
 from urllib.parse import urlparse
+
+from ruamel.yaml import YAML
 
 
 class ExternalCommandException(Exception):
@@ -146,3 +149,9 @@ class DominoCdkUtil:
             return {}
         base_dict = check_type(dictionaries[0])
         return base_dict if len(dictionaries) == 1 else overlay(base_dict, cls.deep_merge(*dictionaries[1:]))
+
+    @staticmethod
+    def ruamel_dump(data: dict):
+        buf = BytesIO()
+        YAML().dump(data, buf)
+        return buf.getvalue().decode()


### PR DESCRIPTION
* Running config is added to the stack as a CloudFormation output
  * This is just a safety / tracking / visibility thing. ie you can recover your settings if you lose your local copy, or if you're looking at what's provisioned you can know what the settings were, etc.
* The agent template now goes through ruamel's dump instead of the standard yaml one
  * Though the motivation was just not to have two different yaml dumpers in the same file, it has the advantage of preserving the order of the original structure, which mimics the order in the actual agent template