### PR TITLE
Handle update cluster scenarios in cluster tagging, k8s logs (PLAT-2515)

### DIFF
--- a/cdk/domino_cdk/provisioners/efs.py
+++ b/cdk/domino_cdk/provisioners/efs.py
@@ -113,7 +113,7 @@ class DominoEfsProvisioner:
             scope=self.scope,
             stack_name=stack_name,
             name="backup_post_creation_tasks",
-            environment={"stack_name": stack_name, "backup_vault": vault.backup_vault_name},
+            properties={"stack_name": stack_name, "backup_vault": vault.backup_vault_name},
             resources=[
                 f"arn:{partition}:backup:{self.scope.region}:{self.scope.account}:backup-vault:{stack_name}-efs",
                 # To limit the recovery points, we will need to add tag checking condition to the IAM policy for the

--- a/cdk/domino_cdk/provisioners/lambda_files/backup_post_creation_tasks.py
+++ b/cdk/domino_cdk/provisioners/lambda_files/backup_post_creation_tasks.py
@@ -1,5 +1,6 @@
 import json
 import os
+import traceback
 
 import boto3
 import requests
@@ -12,23 +13,27 @@ def on_event(event, context):
     print('Debug: environ:', os.environ)
     request_type = event['RequestType']
     response = {}
-    if request_type == 'Create':
-        response = on_create(event)
-    if request_type == 'Delete':
-        response = on_delete(event)
-    if response:
-        event.update(response)
-    event['Status'] = 'SUCCESS'
+    try:
+        if request_type == 'Create':
+            response = on_create(event)
+        if request_type == 'Delete':
+            response = on_delete(event)
+        if response:
+            event.update(response)
+        event['Status'] = 'SUCCESS'
+    except:  # noqa: E722
+        traceback.print_exc()
+        event['Status'] = 'FAILED'
     requests.put(event['ResponseURL'], data=json.dumps(event))
 
 
 def on_create(event):
-    physical_id = f'domino-cluster-{os.environ["stack_name"]}-backup-cleanup'
+    physical_id = f"domino-cluster-{event['ResourceProperties']['stack_name']}-backup-cleanup"
     return {'PhysicalResourceId': physical_id}
 
 
 def on_delete(event):
-    backup_vault_name = os.environ["backup_vault"]
+    backup_vault_name = event['ResourceProperties']['backup_vault']
     print(f'Delete backup points in backup vault {backup_vault_name}')
     response = client.list_recovery_points_by_backup_vault(BackupVaultName=backup_vault_name)
     for rp in response['RecoveryPoints']:

--- a/cdk/domino_cdk/provisioners/lambda_files/cluster_post_creation_tasks.py
+++ b/cdk/domino_cdk/provisioners/lambda_files/cluster_post_creation_tasks.py
@@ -1,6 +1,7 @@
 import json
 import os
 import time
+import traceback
 
 import boto3
 import requests
@@ -11,46 +12,70 @@ def on_event(event, context):
     print('Debug: environ:', os.environ)
     request_type = event['RequestType']
     response = {}
-    if request_type == 'Create':
-        response = on_create(event)
-    event.update(response)
-    event['Status'] = 'SUCCESS'
+    try:
+        if request_type == 'Create':
+            response = on_create(event)
+        if request_type == 'Update':
+            response = on_update(event)
+        if response:
+            event.update(response)
+        event['Status'] = 'SUCCESS'
+    except:  # noqa: E722
+        traceback.print_exc()
+        event['Status'] = 'FAILED'
     requests.put(event['ResponseURL'], data=json.dumps(event))
+
+
+def tag_cluster(event, eks_client):
+    cluster_arn = event['ResourceProperties']['cluster_arn']
+    print(f'Tag cluster {cluster_arn}')
+    eks_client.tag_resource(
+        resourceArn=cluster_arn,
+        tags=event['ResourceProperties']['tags'],
+    )
+
+
+def on_update(event):
+    eks_client = boto3.client('eks')
+    tag_cluster(event, eks_client)
 
 
 def on_create(event):
     logs_client = boto3.client('logs')
     eks_client = boto3.client('eks')
-    cluster_name = os.environ["cluster"]
-    cluster_arn = os.environ["cluster_arn"]
+    cluster_name = event['ResourceProperties']['cluster_name']
 
-    print(f'Tag cluster {cluster_arn}')
-    eks_client.tag_resource(
-        resourceArn=cluster_arn,
-        tags=json.loads(os.environ['tags']),
-    )
+    tag_cluster(event, eks_client)
 
-    print(f'Enable logging in cluster {cluster_arn}')
-    eks_client.update_cluster_config(
-        name=os.environ['cluster'],
-        logging={
-            "clusterLogging": [
-                {
-                    "enabled": True,
-                    "types": ["api", "audit", "authenticator", "controllerManager", "scheduler"],
-                },
-            ],
-        },
-    )
+    print(f'Enable logging in cluster {cluster_name}')
+    try:
+        eks_client.update_cluster_config(
+            name=cluster_name,
+            logging={
+                "clusterLogging": [
+                    {
+                        "enabled": True,
+                        "types": ["api", "audit", "authenticator", "controllerManager", "scheduler"],
+                    },
+                ],
+            },
+        )
+    except eks_client.exceptions.InvalidParameterException as e:
+        if "No changes needed for the logging config provided" not in e.response["Error"]["Message"]:
+            raise
 
-    log_group_name = f'/aws/eks/{cluster_name}/cluster'
-    print(f'Change retention of {log_group_name} log group')
-    while True:  # wait till lambda timeout is reached
-        response = logs_client.describe_log_groups(logGroupNamePrefix=log_group_name, limit=50)
-        if response['logGroups']:
-            break
+    while not set_log_groups_retention(f'/aws/eks/{cluster_name}/cluster', logs_client):
+        # No limit here. Wait till lambda timeout is reached
         time.sleep(30)
-    logs_client.put_retention_policy(logGroupName=log_group_name, retentionInDays=7)
 
     physical_id = f'domino-cluster-{cluster_name}-eks-cluster-task'
     return {'PhysicalResourceId': physical_id}
+
+
+def set_log_groups_retention(log_group_name_prefix, logs_client):
+    print(f'Change retention of all {log_group_name_prefix}* log groups')
+    response = logs_client.describe_log_groups(logGroupNamePrefix=log_group_name_prefix, limit=50)
+    for lg in response['logGroups']:
+        print(f'Change retention of log group {lg["logGroupName"]}')
+        logs_client.put_retention_policy(logGroupName=lg['logGroupName'], retentionInDays=7)
+    return len(response['logGroups'])

--- a/cdk/domino_cdk/provisioners/lambda_files/cluster_post_deletion_tasks.py
+++ b/cdk/domino_cdk/provisioners/lambda_files/cluster_post_deletion_tasks.py
@@ -1,5 +1,6 @@
 import json
 import os
+import traceback
 
 import boto3
 import requests
@@ -10,28 +11,37 @@ def on_event(event, context):
     print('Debug: environ:', os.environ)
     request_type = event['RequestType']
     response = {}
-    if request_type == 'Create':
-        response = on_create(event)
-    if request_type == 'Delete':
-        response = on_delete(event)
-    event.update(response)
-    event['Status'] = 'SUCCESS'
+    try:
+        if request_type == 'Create':
+            response = on_create(event)
+        if request_type == 'Delete':
+            response = on_delete(event)
+        if response:
+            event.update(response)
+        event['Status'] = 'SUCCESS'
+    except:  # noqa: E722
+        traceback.print_exc()
+        event['Status'] = 'FAILED'
     requests.put(event['ResponseURL'], data=json.dumps(event))
 
 
 def on_create(event):
-    cluster_name = os.environ['cluster']
+    cluster_name = event['ResourceProperties']['cluster_name']
     physical_id = f'domino-cluster-{cluster_name}-logs-cleanup'
     return {'PhysicalResourceId': physical_id}
 
 
 def on_delete(event):
     logs_client = boto3.client('logs')
-    cluster_name = os.environ['cluster']
-    log_group_name = f'/aws/lambda/{cluster_name}'
-    print(f'Change retention of all {log_group_name} log groups')
-    response = logs_client.describe_log_groups(logGroupNamePrefix=log_group_name, limit=50)
+    cluster_name = event['ResourceProperties']['cluster_name']
+    set_log_groups_retention(f'/aws/lambda/{cluster_name}', logs_client)
+    set_log_groups_retention(f'/aws/eks/{cluster_name}/cluster', logs_client)
+    return {}
+
+
+def set_log_groups_retention(log_group_name_prefix, logs_client):
+    print(f'Change retention of all {log_group_name_prefix}* log groups')
+    response = logs_client.describe_log_groups(logGroupNamePrefix=log_group_name_prefix, limit=50)
     for lg in response['logGroups']:
         print(f'Change retention of log group {lg["logGroupName"]}')
         logs_client.put_retention_policy(logGroupName=lg['logGroupName'], retentionInDays=1)
-    return {}

--- a/cdk/domino_cdk/provisioners/lambda_utils.py
+++ b/cdk/domino_cdk/provisioners/lambda_utils.py
@@ -1,5 +1,5 @@
 from os import path
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 
 import aws_cdk.aws_iam as iam
 import aws_cdk.aws_lambda as lambda_
@@ -11,9 +11,10 @@ def create_lambda(
     scope: cdk.Construct,
     stack_name: str,
     name: str,
-    environment: Dict[str, str],
     resources: List[str],
     actions: List[str],
+    properties: Optional[Dict[str, Any]] = None,
+    environment: Optional[Dict[str, Any]] = None,
 ) -> cdk.Construct:
     dirname = path.dirname(path.abspath(__file__))
     with open(path.join(dirname, "lambda_files", f"{name}.py"), encoding="utf-8") as fp:
@@ -36,6 +37,4 @@ def create_lambda(
         statement.add_actions(a)
     on_event.add_to_role_policy(statement)
 
-    return cdk.CustomResource(
-        scope, f"{name}_custom", service_token=cdk.Token.as_string(on_event.node.default_child.get_att('Arn'))
-    )
+    return cdk.CustomResource(scope, f"{name}_custom", service_token=on_event.function_arn, properties=properties)


### PR DESCRIPTION
JIRA: https://dominodatalab.atlassian.net/browse/PLAT-2515

Fixes:
1. Parameters are passed to lambdas using custom resource parameters, not environmant.
2. Thanks to that, now the custom resource for tagging function is UPDATED when tags are changing.
3. We handle tags in on_update function
4. Cluster log group is handled as well
5. Better failure handling in lambdas by actually reporting the failure
6. Cluster log enablement doesn't fail if already enabled