### PR TITLE
Make nested stacks default

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -53,8 +53,8 @@ jobs:
         ./util.py load_config -f ./config.yaml
     - name: Test default config (single and nested stacks)
       run: |
+        cdk synth --context singlestack=true -q
         cdk synth -q
-        cdk synth --context nest=true -q
     - name: Upload distribution artifacts
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.DOMINO_ARTIFACTS_KEY_ID }}

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -11,7 +11,7 @@ app = core.App()
 with open(app.node.try_get_context("config") or "config.yaml") as f:
     cfg = config_loader(yaml_load(f, Loader=SafeLoader))
 
-nest = app.node.try_get_context("nest") or False
+nest = app.node.try_get_context("singlestack") or True
 
 DominoStack(
     app,

--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -17,7 +17,7 @@ from domino_cdk.util import DominoCdkUtil
 
 class DominoStack(cdk.Stack):
     def __init__(
-        self, scope: cdk.Construct, construct_id: str, cfg: DominoCDKConfig, nest: bool = False, **kwargs
+        self, scope: cdk.Construct, construct_id: str, cfg: DominoCDKConfig, nest: bool = True, **kwargs
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 


### PR DESCRIPTION
* Make nested stacks the default
* However, for TemplateAssertions (used in unit tests) still needs single stacks, since it can't work with nested stacks and nested stack resources aren't visible in the parent stack
* So keep the nest option in each provisioner
* And flip the default to nested so we can still test single stack mode for the sake of the unit tests