### PR TITLE
Upload release artifacts to S3 during CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -60,8 +60,9 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.DOMINO_ARTIFACTS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.DOMINO_ARTIFACTS_ACCESS_KEY }}
         DOMINO_CDK_VERSION: ${{ github.sha }}
+        DATEDIR: "date +%Y%m%d"
       run: |
         cd ..
         make clean && make dist
-        aws s3 cp --acl=public-read ./dist/domino-cdk-$DOMINO_CDK_VERSION.tar.gz s3://domino-artifacts/cdk/
-        aws s3 cp --acl=public-read ./dist/domino-cdk-terraform-$DOMINO_CDK_VERSION.tar.gz s3://domino-artifacts/cdk/
+        aws s3 cp --acl=public-read ./dist/domino-cdk-$DOMINO_CDK_VERSION.tar.gz s3://domino-artifacts/cdk/$($DATEDIR)/
+        aws s3 cp --acl=public-read ./dist/domino-cdk-terraform-$DOMINO_CDK_VERSION.tar.gz s3://domino-artifacts/cdk/$($DATEDIR)/

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
-        pip install awscli
+        pip install awscli build
     - name: Lint with flake8/black/isort
       run: |
         export FILES=(*.py domino_cdk tests)

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -64,5 +64,8 @@ jobs:
       run: |
         cd ..
         make clean && make dist
-        aws s3 cp --acl=public-read ./dist/domino-cdk-$DOMINO_CDK_VERSION.tar.gz s3://domino-artifacts/cdk/$($DATEDIR)/
-        aws s3 cp --acl=public-read ./dist/domino-cdk-terraform-$DOMINO_CDK_VERSION.tar.gz s3://domino-artifacts/cdk/$($DATEDIR)/
+        for suffix in "" "-terraform"; do
+        filename="domino-cdk$suffix-$DOMINO_CDK_VERSION.tar.gz"
+        aws s3 cp --acl=public-read ./dist/$filename s3://domino-artifacts/cdk/$($DATEDIR)/$filename
+        echo "Artifact url: https://domino-artifacts.s3.amazonaws.com/cdk/$($DATEDIR)/$filename"
+        done

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
+        pip install awscli
     - name: Lint with flake8/black/isort
       run: |
         export FILES=(*.py domino_cdk tests)
@@ -57,5 +58,10 @@ jobs:
     - name: Upload distribution artifacts
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.DOMINO_ARTIFACTS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.DOMINO_ARTIFACTS_ACCESS_KEY }}
+        DOMINO_CDK_VERSION: ${{ github.sha }}
       run: |
-        echo $AWS_ACCESS_KEY_ID | cut -c1-4
+        cd ..
+        make clean && make dist
+        aws s3 cp --acl=public-read ./dist/domino-cdk-$DOMINO_CDK_VERSION.tar.gz s3://domino-artifacts/cdk/
+        aws s3 cp --acl=public-read ./dist/domino-cdk-terraform-$DOMINO_CDK_VERSION.tar.gz s3://domino-artifacts/cdk/

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -54,3 +54,8 @@ jobs:
       run: |
         cdk synth -q
         cdk synth --context nest=true -q
+    - name: Upload distribution artifacts
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.DOMINO_ARTIFACTS_KEY_ID }}
+      run: |
+        echo $AWS_ACCESS_KEY_ID | cut -c1-4

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 DIST_DIR=dist
 TERRAFORM_DIST_NAME=domino-cdk-terraform
 
-VERSION := $(shell python -c "from cdk.domino_cdk import __version__; print(__version__)")
+ifdef DOMINO_CDK_VERSION
+    VERSION := $(DOMINO_CDK_VERSION)
+else
+    VERSION := $(shell python -c "from cdk.domino_cdk import __version__; print(__version__)")
+endif
 
 .PHONY: dist
 

--- a/cdk/domino_cdk/__init__.py
+++ b/cdk/domino_cdk/__init__.py
@@ -1,1 +1,3 @@
-__version__ = "0.0.1-rc3"
+from os import getenv
+
+__version__ = getenv("DOMINO_CDK_VERSION", "0.0.1-rc3")


### PR DESCRIPTION
This PR adds the release artifacts created via `make dist` to an s3 bucket as publicly-accessible downloads.

Our current process for testing deployer integration involves creating a mutable pre-release (rc) tag in github, and iterating over it until the deployer PR is merged (at which point it becomes immutable). This is rather asinine.

With this, one can just use the s3 links CI uses to test, and then create a proper github release (still manually for now) once it's actually merged. No more iterating via github.