### PR TITLE
add SSM support & IMDSv2 requirement to bastion

### DIFF
--- a/cdk/domino_cdk/provisioners/vpc.py
+++ b/cdk/domino_cdk/provisioners/vpc.py
@@ -225,6 +225,10 @@ class DominoVpcProvisioner:
             ),
         )
 
+        bastion_instance.role.add_managed_policy(
+            iam.ManagedPolicy.from_aws_managed_policy_name("AmazonSSMManagedInstanceCore"),
+        )
+
         ec2.CfnEIP(
             self.scope,
             "bastion_eip",
@@ -233,7 +237,7 @@ class DominoVpcProvisioner:
 
         cr.AwsCustomResource(
             self.scope,
-            "DisableBastionHTTPEndpoint",
+            "RequireBastionHTTPTokens",
             log_retention=logs.RetentionDays.ONE_DAY,
             policy=cr.AwsCustomResourcePolicy.from_sdk_calls(resources=cr.AwsCustomResourcePolicy.ANY_RESOURCE),
             on_update=cr.AwsSdkCall(
@@ -241,10 +245,11 @@ class DominoVpcProvisioner:
                 service="EC2",
                 parameters={
                     "InstanceId": bastion_instance.instance_id,
-                    "HttpEndpoint": "disabled",
+                    "HttpTokens": "required",
+                    "HttpEndpoint": "enabled",
                 },
                 physical_resource_id=cr.PhysicalResourceId.of(
-                    f"DisableBastionHTTPEndpoint-{bastion_instance.instance_id}"
+                    f"RequireBastionHTTPTokens-{bastion_instance.instance_id}"
                 ),
             ),
         )

--- a/cdk/domino_cdk/provisioners/vpc.py
+++ b/cdk/domino_cdk/provisioners/vpc.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import aws_cdk.aws_ec2 as ec2
+import aws_cdk.aws_iam as iam
 import aws_cdk.aws_logs as logs
 import aws_cdk.aws_s3 as s3
 import aws_cdk.custom_resources as cr


### PR DESCRIPTION
Although disabled is safest, that doesn't pass AWS' "security compliance" check: 
https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-8

In addition, although it seems a bit strange, we can allow the bastion to be configured with SSM if for some reason SSH doesn't work?