### PR TITLE
support custom root device name for AMIs

### DIFF
--- a/cdk/domino_cdk/config/eks.py
+++ b/cdk/domino_cdk/config/eks.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, TypeVar
 
 from domino_cdk.config.util import check_leavins, from_loader
 
@@ -192,3 +192,7 @@ class EKS:
             ),
             c,
         )
+
+
+# This type enabled correct checking for managed / unmanaged Nodegroups
+T_NodegroupBase = TypeVar("T_NodegroupBase", bound=EKS.NodegroupBase)

--- a/cdk/domino_cdk/config/eks.py
+++ b/cdk/domino_cdk/config/eks.py
@@ -194,5 +194,5 @@ class EKS:
         )
 
 
-# This type enabled correct checking for managed / unmanaged Nodegroups
+# This enables correct type checking for managed / unmanaged Nodegroups
 T_NodegroupBase = TypeVar("T_NodegroupBase", bound=EKS.NodegroupBase)

--- a/cdk/domino_cdk/provisioners/ami.py
+++ b/cdk/domino_cdk/provisioners/ami.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from typing import Dict
+
+import aws_cdk.aws_logs as logs
+import aws_cdk.custom_resources as cr
+from aws_cdk import core as cdk
+
+
+@dataclass
+class DeviceMapping:
+    name: str
+
+
+ami_map: Dict[str, DeviceMapping] = {}
+
+
+def root_device_mapping(scope: cdk.Construct, ami_id: str) -> DeviceMapping:
+    if device_mapping := ami_map.get(ami_id):
+        return device_mapping
+
+    root_device_name_cr = cr.AwsCustomResource(
+        scope,
+        f"ImageRootDeviceName-{ami_id}",
+        log_retention=logs.RetentionDays.ONE_DAY,
+        policy=cr.AwsCustomResourcePolicy.from_sdk_calls(resources=cr.AwsCustomResourcePolicy.ANY_RESOURCE),
+        on_update=cr.AwsSdkCall(
+            action="describeImages",
+            service="EC2",
+            output_paths=["Images.0.RootDeviceName"],
+            parameters={
+                "ImageIds": [ami_id],
+            },
+            physical_resource_id=cr.PhysicalResourceId.of(f"ImageRootDeviceName-{ami_id}"),
+        ),
+    )
+
+    root_device_name = root_device_name_cr.get_response_field("Images.0.RootDeviceName")
+    ami_map[ami_id] = DeviceMapping(root_device_name)
+    return ami_map[ami_id]

--- a/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
@@ -262,9 +262,10 @@ class DominoEksNodegroupProvisioner:
         return mime_user_data
 
     def _launch_template(self, scope, name: str, ng: NodeGroup, **opts) -> ec2.LaunchTemplate:
-        root_device_name = "/dev/xvda"  # This only works for AL2
         if ng.ami_id:
             root_device_name = root_device_mapping(self.scope, ng.ami_id).name
+        else:
+            root_device_name = "/dev/xvda"  # This only works for AL2
 
         opts = {
             "key_name": ng.key_name,

--- a/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, TypeVar, Union
+from typing import Any, Dict, List, Optional, TypeVar, Union
 
 import aws_cdk.aws_ec2 as ec2
 import aws_cdk.aws_eks as eks

--- a/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Dict, List, Optional, TypeVar, Union
 
 import aws_cdk.aws_ec2 as ec2
 import aws_cdk.aws_eks as eks
@@ -7,6 +7,10 @@ from aws_cdk import aws_autoscaling
 from aws_cdk import core as cdk
 
 from domino_cdk import config
+
+from ..ami import root_device_mapping
+
+NodeGroup = TypeVar("NodeGroup", bound=config.EKS.NodegroupBase)
 
 
 class DominoEksNodegroupProvisioner:
@@ -34,7 +38,7 @@ class DominoEksNodegroupProvisioner:
 
         max_nodegroup_azs = self.eks_cfg.max_nodegroup_azs
 
-        def provision_nodegroup(nodegroup: Dict[str, config.EKS.NodegroupBase], prov_func):
+        def provision_nodegroup(nodegroup: Dict[str, NodeGroup], prov_func):
             for name, ng in nodegroup.items():
                 if not ng.ami_id:
                     ng.labels = {**ng.labels, **self.eks_cfg.global_node_labels}
@@ -48,31 +52,16 @@ class DominoEksNodegroupProvisioner:
         provision_nodegroup(self.eks_cfg.managed_nodegroups, self.provision_managed_nodegroup)
         provision_nodegroup(self.eks_cfg.unmanaged_nodegroups, self.provision_unmanaged_nodegroup)
 
-    def provision_managed_nodegroup(
-        self, name: str, ng: Type[config.EKS.NodegroupBase], max_nodegroup_azs: int
-    ) -> None:
+    def provision_managed_nodegroup(self, name: str, ng: NodeGroup, max_nodegroup_azs: int) -> None:
         region = cdk.Stack.of(self.scope).region
         machine_image: Optional[ec2.IMachineImage] = (
             ec2.MachineImage.generic_linux({region: ng.ami_id}) if ng.ami_id else None
         )
         mime_user_data: Optional[ec2.UserData] = self._handle_user_data(name, ng.ami_id, ng.ssm_agent, [ng.user_data])
 
-        lt = ec2.LaunchTemplate(
-            self.cluster,
-            f"LaunchTemplate{name}",
-            key_name=ng.key_name,
-            launch_template_name=f"{self.stack_name}-{name}",
-            block_devices=[
-                ec2.BlockDevice(
-                    device_name="/dev/xvda",  # TODO: this only works for AL2
-                    volume=ec2.BlockDeviceVolume.ebs(
-                        ng.disk_size,
-                        delete_on_termination=True,
-                        encrypted=True,
-                        volume_type=ec2.EbsDeviceVolumeType.GP2,
-                    ),
-                )
-            ],
+        lt = self._launch_template(
+            name,
+            ng,
             machine_image=machine_image,
             user_data=mime_user_data,
         )
@@ -97,9 +86,7 @@ class DominoEksNodegroupProvisioner:
                 node_role=self.ng_role,
             )
 
-    def provision_unmanaged_nodegroup(
-        self, name: str, ng: Type[config.EKS.NodegroupBase], max_nodegroup_azs: int
-    ) -> None:
+    def provision_unmanaged_nodegroup(self, name: str, ng: NodeGroup, max_nodegroup_azs: int) -> None:
         region = cdk.Stack.of(self.scope).region
         machine_image = (
             ec2.MachineImage.generic_linux({region: ng.ami_id})
@@ -167,24 +154,11 @@ class DominoEksNodegroupProvisioner:
             mime_user_data = self._handle_user_data(name, ng.ami_id, ng.ssm_agent, [ng.user_data, asg.user_data])
 
             if not cfn_lt:
-                lt = ec2.LaunchTemplate(
-                    scope,
-                    f"LaunchTemplate{i}",
-                    launch_template_name=indexed_name,
-                    block_devices=[
-                        ec2.BlockDevice(
-                            device_name="/dev/xvda",
-                            volume=ec2.BlockDeviceVolume.ebs(
-                                ng.disk_size,
-                                delete_on_termination=True,
-                                encrypted=True,
-                                volume_type=ec2.EbsDeviceVolumeType.GP2,
-                            ),
-                        )
-                    ],
+                lt = self._launch_template(
+                    f"{name}-{az}",
+                    ng,
                     role=self.ng_role,
                     instance_type=ec2.InstanceType(ng.instance_types[0]),
-                    key_name=ng.key_name,
                     machine_image=machine_image,
                     user_data=mime_user_data,
                     security_group=self.unmanaged_sg,
@@ -252,6 +226,7 @@ class DominoEksNodegroupProvisioner:
                     )
                 ),
             )
+
             # if not custom AMI, we can install ssm agent. If requested.
             if ssm_agent:
                 mime_user_data.add_part(
@@ -261,6 +236,7 @@ class DominoEksNodegroupProvisioner:
                         )
                     ),
                 )
+
         for ud in user_data_list:
             if isinstance(ud, str):
                 mime_user_data.add_part(
@@ -281,3 +257,27 @@ class DominoEksNodegroupProvisioner:
                 mime_user_data.add_part(ec2.MultipartBody.from_user_data(ud))
 
         return mime_user_data
+
+    def _launch_template(self, name: str, ng: NodeGroup, **opts) -> ec2.LaunchTemplate:
+        root_device_name = "/dev/xvda"  # This only works for AL2
+        if ng.ami_id:
+            root_device_name = root_device_mapping(self.scope, ng.ami_id).name
+
+        return ec2.LaunchTemplate(
+            self.cluster,
+            name,
+            key_name=ng.key_name,
+            launch_template_name=f"{self.stack_name}-{name}",
+            block_devices=[
+                ec2.BlockDevice(
+                    device_name=root_device_name,
+                    volume=ec2.BlockDeviceVolume.ebs(
+                        ng.disk_size,
+                        delete_on_termination=True,
+                        encrypted=True,
+                        volume_type=ec2.EbsDeviceVolumeType.GP2,
+                    ),
+                )
+            ],
+            **opts,
+        )

--- a/cdk/domino_cdk/provisioners/vpc.py
+++ b/cdk/domino_cdk/provisioners/vpc.py
@@ -174,7 +174,6 @@ class DominoVpcProvisioner:
         if not bastion.enabled:
             return None
 
-        root_device_name = "/dev/xvda"  # This only works for AL2
         if bastion.ami_id:
             region = cdk.Stack.of(self.scope).region
             machine_image = ec2.MachineImage.generic_linux(
@@ -187,6 +186,8 @@ class DominoVpcProvisioner:
             machine_image = ec2.GenericSSMParameterImage(
                 "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2", ec2.OperatingSystemType.LINUX
             )
+
+            root_device_name = "/dev/xvda"  # This only works for AL2
 
         bastion_sg = ec2.SecurityGroup(
             self.scope,

--- a/cdk/domino_cdk/provisioners/vpc.py
+++ b/cdk/domino_cdk/provisioners/vpc.py
@@ -1,12 +1,15 @@
 from typing import Optional
 
 import aws_cdk.aws_ec2 as ec2
+import aws_cdk.aws_iam as iam
 import aws_cdk.aws_logs as logs
 import aws_cdk.aws_s3 as s3
 import aws_cdk.custom_resources as cr
 from aws_cdk import core as cdk
 
 from domino_cdk import config
+
+from .ami import root_device_mapping
 
 _DominoVpcStack = None
 
@@ -170,12 +173,16 @@ class DominoVpcProvisioner:
     def provision_bastion(self, name: str, bastion: config.VPC.Bastion) -> Optional[ec2.SecurityGroup]:
         if not bastion.enabled:
             return None
+
+        root_device_name = "/dev/xvda"  # This only works for AL2
         if bastion.ami_id:
             region = cdk.Stack.of(self.scope).region
             machine_image = ec2.MachineImage.generic_linux(
                 {region: bastion.ami_id},
-                user_data=ec2.UserData.custom(bastion.user_data),
+                user_data=ec2.UserData.custom(bastion.user_data) if bastion.user_data else None,
             )
+
+            root_device_name = root_device_mapping(self.scope, bastion.ami_id).name
         else:
             machine_image = ec2.GenericSSMParameterImage(
                 "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2", ec2.OperatingSystemType.LINUX
@@ -208,9 +215,9 @@ class DominoVpcProvisioner:
             instance_type=ec2.InstanceType(bastion.instance_type),
             block_devices=[
                 ec2.BlockDevice(
-                    device_name="/dev/xvda",  # TODO: this depends on the AMI
+                    device_name=root_device_name,
                     volume=ec2.BlockDeviceVolume.ebs(
-                        40,
+                        40,  # TODO: this requires the AMI volume be <= 40GiB already
                         delete_on_termination=True,
                         encrypted=True,
                         volume_type=ec2.EbsDeviceVolumeType.GP2,


### PR DESCRIPTION
We previously hardcoded `/dev/xvda`, but that only works for AMIs where the root device name matches. If it doesn't, we end up adding a new volume with that name and can potentially not get the root device volume size we need.

This solution is definitely a bit of a PITA for a potential corner case, but it is more "correct". The only speculative issue is the root volume size, which we can't obtain programmatically, because there really isn't a good way to reference it by value.