### PR TITLE
Master branch reports error during CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,7 +154,7 @@ jobs:
         sleep 120 # Immediate destroy after cdk deploy causes race conditions + give k8s time to deprovision after domino Uninstall
         cdk destroy --force
     - name: Fail without deploy
-      if: ${{ github.event.pull_request.draft == false && ! contains(github.event.pull_request.labels.*.name, 'deploy-test') || github.ref == 'refs/heads/master' }}
+      if: ${{ github.event.pull_request.draft == false && ! (contains(github.event.pull_request.labels.*.name, 'deploy-test') || github.ref == 'refs/heads/master') }}
       run: |
         echo "Deploy tests required on non-draft PRs. Please add 'deploy-test' label".
         exit 1


### PR DESCRIPTION
A conditional is missing some parens in a circumstance that only happens on the master branch. Fix the minor error.

Will probably turbomerge.