### PR TITLE
ensure nginx-ingress does not use proxy-protocol with istio

### DIFF
--- a/cdk/domino_cdk/agent.py
+++ b/cdk/domino_cdk/agent.py
@@ -120,14 +120,15 @@ def generate_install_config(
     }
 
     if install.istio_compatible:
+        agent_cfg["istio"] = {
+            "enabled": True,
+            "install": True,
+            "cni": False,
+        }
+
         agent_cfg = DominoCdkUtil.deep_merge(
             agent_cfg,
             {
-                "istio": {
-                    "enabled": True,
-                    "install": True,
-                    "cni": False,
-                },
                 "services": {
                     "nginx_ingress": {
                         "chart_values": {

--- a/cdk/domino_cdk/agent.py
+++ b/cdk/domino_cdk/agent.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 from aws_cdk.aws_s3 import Bucket
 
 from domino_cdk.config import Install
+from domino_cdk.util import DominoCdkUtil
 
 
 def generate_install_config(
@@ -101,7 +102,6 @@ def generate_install_config(
         "controller": {
             "kind": "Deployment",
             "hostNetwork": False,
-            "config": {"use-proxy-protocol": "true"},
             "service": {
                 "enabled": True,
                 "type": "LoadBalancer",
@@ -111,15 +111,69 @@ def generate_install_config(
                     "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "tcp",
                     "service.beta.kubernetes.io/aws-load-balancer-ssl-ports": "443",
                     "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",  # noqa
-                    "service.beta.kubernetes.io/aws-load-balancer-proxy-protocol": "*",
                     # "service.beta.kubernetes.io/aws-load-balancer-security-groups":
                     #     "could-propagate-this-instead-of-create"
                 },
-                "targetPorts": {"http": "http", "https": "http"},
                 "loadBalancerSourceRanges": install.access_list,
             },
         }
     }
+
+    if install.istio_compatible:
+        agent_cfg = DominoCdkUtil.deep_merge(
+            agent_cfg,
+            {
+                "istio": {
+                    "enabled": True,
+                    "install": True,
+                    "cni": False,
+                },
+                "services": {
+                    "nginx_ingress": {
+                        "chart_values": {
+                            "controller": {
+                                "config": {
+                                    "use-proxy-protocol": "false",
+                                    # AWS ELBs don't like nginx-ingress's default cipher suite--connections just hang w/ override
+                                    "ssl-ciphers": "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES128-SHA256:AES256-GCM-SHA384:AES256-SHA256:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA",  # noqa
+                                    "ssl-protocols": "TLSv1.2 TLSv1.3",
+                                },
+                                "service": {
+                                    "targetPorts": {"http": "http", "https": "https"},
+                                    "annotations": {
+                                        "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "ssl"
+                                    },
+                                },
+                            }
+                        }
+                    }
+                },
+            },
+        )
+
+    else:
+        agent_cfg = DominoCdkUtil.deep_merge(
+            agent_cfg,
+            {
+                "services": {
+                    "nginx_ingress": {
+                        "chart_values": {
+                            "controller": {
+                                "config": {
+                                    "use-proxy-protocol": "true",
+                                },
+                                "service": {
+                                    "targetPorts": {"http": "http", "https": "http"},
+                                    "annotations": {
+                                        "service.beta.kubernetes.io/aws-load-balancer-proxy-protocol": "*",
+                                    },
+                                },
+                            }
+                        }
+                    }
+                }
+            },
+        )
 
     if monitoring_bucket:
         agent_cfg["services"]["nginx_ingress"]["chart_values"].update(

--- a/cdk/domino_cdk/config/install.py
+++ b/cdk/domino_cdk/config/install.py
@@ -26,6 +26,7 @@ class Install:
     registry_username: str
     registry_password: str
     overrides: dict
+    istio_compatible: bool
 
     @staticmethod
     def from_0_0_0(c: dict):
@@ -37,6 +38,7 @@ class Install:
                 hostname=None,
                 registry_username=None,
                 registry_password=None,
+                istio_compatible=False,
                 overrides=c,
             ),
             c,
@@ -53,6 +55,7 @@ class Install:
                 registry_username=c.pop("registry_username"),
                 registry_password=c.pop("registry_password"),
                 overrides=c.pop("overrides"),
+                istio_compatible=c.pop("istio_compatible", False),
             ),
             c,
         )

--- a/cdk/domino_cdk/config/template.py
+++ b/cdk/domino_cdk/config/template.py
@@ -156,38 +156,6 @@ def config_template(
 
     overrides: Dict[Any, Any] = {}
 
-    if istio_compatible:
-        overrides = DominoCdkUtil.deep_merge(
-            overrides,
-            {
-                "istio": {
-                    "enabled": True,
-                    "install": True,
-                    "cni": False,
-                },
-                "services": {
-                    "nginx_ingress": {
-                        "chart_values": {
-                            "controller": {
-                                "config": {
-                                    "use-proxy-protocol": "false",
-                                    # AWS ELBs don't like nginx-ingress's default cipher suite--connections just hang w/ override
-                                    "ssl-ciphers": "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES128-SHA256:AES256-GCM-SHA384:AES256-SHA256:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA",  # noqa
-                                    "ssl-protocols": "TLSv1.2 TLSv1.3",
-                                },
-                                "service": {
-                                    "targetPorts": {"http": "http", "https": "https"},
-                                    "annotations": {
-                                        "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "ssl"
-                                    },
-                                },
-                            }
-                        }
-                    }
-                },
-            },
-        )
-
     if dev_defaults:
         overrides = DominoCdkUtil.deep_merge(
             overrides,
@@ -214,6 +182,7 @@ def config_template(
         hostname=hostname,
         registry_username=registry_username,
         registry_password=registry_password,
+        istio_compatible=istio_compatible,
         overrides=overrides,
     )
 

--- a/cdk/tests/unit/config/__init__.py
+++ b/cdk/tests/unit/config/__init__.py
@@ -25,6 +25,7 @@ default_config = DominoCDKConfig(
         hostname=None,
         registry_username=None,
         registry_password=None,
+        istio_compatible=False,
         overrides={},
     ),
     vpc=VPC(
@@ -219,6 +220,7 @@ legacy_config = DominoCDKConfig(
         hostname=None,
         registry_username=None,
         registry_password=None,
+        istio_compatible=False,
         overrides={},
     ),
     vpc=VPC(

--- a/cdk/tests/unit/config/test_config.py
+++ b/cdk/tests/unit/config/test_config.py
@@ -60,79 +60,10 @@ class TestConfig(unittest.TestCase):
     def test_istio(self):
         c = config_template(istio_compatible=True)
         self.assertEqual(["m5.4xlarge"], c.eks.unmanaged_nodegroups["platform-0"].instance_types)
-        self.assertEqual(
-            c.install.overrides,
-            {
-                "istio": {
-                    "enabled": True,
-                    "install": True,
-                    "cni": False,
-                },
-                "services": {
-                    "nginx_ingress": {
-                        "chart_values": {
-                            "controller": {
-                                "config": {
-                                    "use-proxy-protocol": "false",
-                                    "ssl-ciphers": "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES128-SHA256:AES256-GCM-SHA384:AES256-SHA256:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA",  # noqa
-                                    "ssl-protocols": "TLSv1.2 TLSv1.3",
-                                },
-                                "service": {
-                                    "targetPorts": {"http": "http", "https": "https"},
-                                    "annotations": {
-                                        "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "ssl"
-                                    },
-                                },
-                            }
-                        }
-                    }
-                },
-            },
-        )
 
     def test_istio_dev(self):
         c = config_template(istio_compatible=True, dev_defaults=True)
         self.assertEqual(["m5.4xlarge"], c.eks.unmanaged_nodegroups["platform-0"].instance_types)
-        self.assertEqual(
-            c.install.overrides,
-            {
-                "istio": {
-                    "enabled": True,
-                    "install": True,
-                    "cni": False,
-                },
-                "services": {
-                    "nucleus": {
-                        "chart_values": {
-                            "replicaCount": {
-                                "dispatcher": 1,
-                                "frontend": 1,
-                            },
-                            "keycloak": {
-                                "createIntegrationTestUser": True,
-                            },
-                        },
-                    },
-                    "nginx_ingress": {
-                        "chart_values": {
-                            "controller": {
-                                "config": {
-                                    "use-proxy-protocol": "false",
-                                    "ssl-ciphers": "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES128-SHA256:AES256-GCM-SHA384:AES256-SHA256:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA",  # noqa
-                                    "ssl-protocols": "TLSv1.2 TLSv1.3",
-                                },
-                                "service": {
-                                    "targetPorts": {"http": "http", "https": "https"},
-                                    "annotations": {
-                                        "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "ssl"
-                                    },
-                                },
-                            }
-                        }
-                    },
-                },
-            },
-        )
 
     def test_dev(self):
         c = config_template(dev_defaults=True)

--- a/cdk/tests/unit/test_agent.py
+++ b/cdk/tests/unit/test_agent.py
@@ -13,6 +13,12 @@ class TestAgent(TestCase):
     def setUp(self):
         self.app = App()
         self.stack = Stack(self.app, "VPC", env=Environment(region="us-west-2", account="1234567890"))
+        self.buckets = {
+            "blobs": Bucket(self.stack, "s3-blobs"),
+            "logs": Bucket(self.stack, "s3-logs"),
+            "backups": Bucket(self.stack, "s3-backups"),
+            "registry": Bucket(self.stack, "s3-registry"),
+        }
 
     def test_generate_intsall_config_istio(self):
         config = generate_install_config(
@@ -30,12 +36,7 @@ class TestAgent(TestCase):
             "test-cluster",
             "10.0.0.0/16",
             {},
-            {
-                "blobs": Bucket(self.stack, "s3-blobs"),
-                "logs": Bucket(self.stack, "s3-logs"),
-                "backups": Bucket(self.stack, "s3-backups"),
-                "registry": Bucket(self.stack, "s3-registry"),
-            },
+            self.buckets,
             None,
             "efs:ap-id",
             "ZONE-ABC",
@@ -87,12 +88,7 @@ class TestAgent(TestCase):
             "test-cluster",
             "10.0.0.0/16",
             {},
-            {
-                "blobs": Bucket(self.stack, "s3-blobs"),
-                "logs": Bucket(self.stack, "s3-logs"),
-                "backups": Bucket(self.stack, "s3-backups"),
-                "registry": Bucket(self.stack, "s3-registry"),
-            },
+            self.buckets,
             None,
             "efs:ap-id",
             "ZONE-ABC",

--- a/cdk/tests/unit/test_agent.py
+++ b/cdk/tests/unit/test_agent.py
@@ -1,0 +1,128 @@
+from unittest import TestCase
+
+from aws_cdk.aws_s3 import Bucket
+from aws_cdk.core import App, Environment, Stack
+
+from domino_cdk.agent import generate_install_config
+from domino_cdk.config import Install
+
+
+class TestAgent(TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.app = App()
+        self.stack = Stack(self.app, "VPC", env=Environment(region="us-west-2", account="1234567890"))
+
+    def test_generate_intsall_config_istio(self):
+        config = generate_install_config(
+            "test",
+            Install(
+                access_list="0.0.0.0/0",
+                acm_cert_arn="acm:cert:arn",
+                hostname="test.example.com",
+                registry_username=None,
+                registry_password=None,
+                overrides={},
+                istio_compatible=True,
+            ),
+            "us-west-2",
+            "test-cluster",
+            "10.0.0.0/16",
+            {},
+            {
+                "blobs": Bucket(self.stack, "s3-blobs"),
+                "logs": Bucket(self.stack, "s3-logs"),
+                "backups": Bucket(self.stack, "s3-backups"),
+                "registry": Bucket(self.stack, "s3-registry"),
+            },
+            None,
+            "efs:ap-id",
+            "ZONE-ABC",
+            "TXTOWNER",
+        )
+
+        self.assertEqual(config["istio"], {"enabled": True, "install": True, "cni": False})
+        self.assertEqual(
+            config["services"]["nginx_ingress"]["chart_values"],
+            {
+                "controller": {
+                    "kind": "Deployment",
+                    "hostNetwork": False,
+                    "service": {
+                        "enabled": True,
+                        "type": "LoadBalancer",
+                        "targetPorts": {"http": "http", "https": "https"},
+                        "annotations": {
+                            "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "ssl",
+                            "service.beta.kubernetes.io/aws-load-balancer-ssl-cert": "acm:cert:arn",
+                            "service.beta.kubernetes.io/aws-load-balancer-internal": False,
+                            "service.beta.kubernetes.io/aws-load-balancer-ssl-ports": "443",
+                            "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",  # noqa
+                        },
+                        "loadBalancerSourceRanges": "0.0.0.0/0",
+                    },
+                    "config": {
+                        "use-proxy-protocol": "false",
+                        "ssl-ciphers": "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES128-SHA256:AES256-GCM-SHA384:AES256-SHA256:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA",  # noqa
+                        "ssl-protocols": "TLSv1.2 TLSv1.3",
+                    },
+                }
+            },
+        )
+
+    def test_generate_intsall_config(self):
+        config = generate_install_config(
+            "test",
+            Install(
+                access_list="0.0.0.0/0",
+                acm_cert_arn="acm:cert:arn",
+                hostname="test.example.com",
+                registry_username=None,
+                registry_password=None,
+                overrides={},
+                istio_compatible=False,
+            ),
+            "us-west-2",
+            "test-cluster",
+            "10.0.0.0/16",
+            {},
+            {
+                "blobs": Bucket(self.stack, "s3-blobs"),
+                "logs": Bucket(self.stack, "s3-logs"),
+                "backups": Bucket(self.stack, "s3-backups"),
+                "registry": Bucket(self.stack, "s3-registry"),
+            },
+            None,
+            "efs:ap-id",
+            "ZONE-ABC",
+            "TXTOWNER",
+        )
+
+        self.assertEqual(config.get("istio"), None)
+        self.assertEqual(
+            config["services"]["nginx_ingress"]["chart_values"],
+            {
+                "controller": {
+                    "kind": "Deployment",
+                    "hostNetwork": False,
+                    "service": {
+                        "enabled": True,
+                        "type": "LoadBalancer",
+                        "targetPorts": {"http": "http", "https": "http"},
+                        "annotations": {
+                            "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "tcp",
+                            "service.beta.kubernetes.io/aws-load-balancer-ssl-cert": "acm:cert:arn",
+                            "service.beta.kubernetes.io/aws-load-balancer-internal": False,
+                            "service.beta.kubernetes.io/aws-load-balancer-ssl-ports": "443",
+                            "service.beta.kubernetes.io/aws-load-balancer-proxy-protocol": "*",
+                            "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",  # noqa
+                        },
+                        "loadBalancerSourceRanges": "0.0.0.0/0",
+                    },
+                    "config": {
+                        "use-proxy-protocol": "true",
+                    },
+                }
+            },
+        )


### PR DESCRIPTION
I missed the service annotation for the proxy protocol leading to a mismatch between the nginx config and ELB.