### PR TITLE
PLAT-2499: Make bucket roles strict, names (sanely) configurable

### DIFF
--- a/cdk/domino_cdk/__init__.py
+++ b/cdk/domino_cdk/__init__.py
@@ -1,3 +1,3 @@
 from os import getenv
 
-__version__ = getenv("DOMINO_CDK_VERSION", "0.0.1-rc5")
+__version__ = getenv("DOMINO_CDK_VERSION", "0.0.1")

--- a/cdk/domino_cdk/config/base.py
+++ b/cdk/domino_cdk/config/base.py
@@ -129,13 +129,17 @@ class DominoCDKConfig:
         def r_vars(c, indent: int):
             indent += 2
             if is_dataclass(c):
-                cm = CommentedMap({(x if x != "_tags" else "tags"): r_vars(y, indent) for x, y in vars(c).items()})
+                hidden = getattr(c, "_hidden", [])
+                cm = CommentedMap({(x if x != "_tags" else "tags"): r_vars(y, indent) for x, y in vars(c).items() if x not in hidden or y})
                 if not disable_comments:
                     [
                         cm.yaml_set_comment_before_after_key(k, after=dedent(v.__doc__).strip(), after_indent=indent)
                         for k, v in vars(c).items()
-                        if is_dataclass(v) and getattr(v, "__doc__")
+                        if is_dataclass(v) and getattr(v, "__doc__") and not getattr(v, "_no_doc", False)
                     ]
+                else:
+                    print(getattr(c, "_no_doc", False))
+                    print(getattr(c, "__doc__"))
                 return cm
             elif type(c) == list:
                 return [r_vars(x, indent) for x in c]

--- a/cdk/domino_cdk/config/base.py
+++ b/cdk/domino_cdk/config/base.py
@@ -130,7 +130,13 @@ class DominoCDKConfig:
             indent += 2
             if is_dataclass(c):
                 hidden = getattr(c, "_hidden", [])
-                cm = CommentedMap({(x if x != "_tags" else "tags"): r_vars(y, indent) for x, y in vars(c).items() if x not in hidden or y})
+                cm = CommentedMap(
+                    {
+                        (x if x != "_tags" else "tags"): r_vars(y, indent)
+                        for x, y in vars(c).items()
+                        if x not in hidden or y
+                    }
+                )
                 if not disable_comments:
                     [
                         cm.yaml_set_comment_before_after_key(k, after=dedent(v.__doc__).strip(), after_indent=indent)

--- a/cdk/domino_cdk/config/s3.py
+++ b/cdk/domino_cdk/config/s3.py
@@ -69,8 +69,6 @@ class S3:
     def from_0_0_0(c: dict):
         return from_loader(
             "config.s3",
-            S3(
-                buckets=S3.BucketList.load(c.pop("buckets"))
-            ),
+            S3(buckets=S3.BucketList.load(c.pop("buckets"))),
             c,
         )

--- a/cdk/domino_cdk/config/s3.py
+++ b/cdk/domino_cdk/config/s3.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, Optional
 
-from domino_cdk.config.util import from_loader
+from domino_cdk.config.util import check_leavins, from_loader
 
 
 @dataclass
@@ -9,9 +9,12 @@ class S3:
     """
     Map of buckets to create and provide IAM access from the EKS cluster.
 
-    The monitoring bucket is optionally created to store various operational logs: VPC flow logs, S3 and ELB access logs.
+    "blobs", "logs", "backups" and "registry" buckets are MANDATORY.
+
+    The "monitoring" bucket is optionally created to store various operational logs: VPC flow logs, S3 and ELB access logs.
 
     Bucket parameters:
+    name: "my-bucket-name" - Optional name to override default bucketname of deployname-bucket-type
     auto_delete_objects: true/false - Delete entire contents of bucket when destroying the CloudFormation stack
     removal_policy_destroy: true/false - Delete bucket when destroying stack. If auto_delete_objects is false,
                                          destroys will fail unless buckets are emptied.
@@ -19,30 +22,55 @@ class S3:
     """
 
     @dataclass
-    class Bucket:
-        auto_delete_objects: bool
-        removal_policy_destroy: bool
-        sse_kms_key_id: Optional[str]
+    class BucketList:
+        @dataclass
+        class Bucket:
+            auto_delete_objects: bool
+            removal_policy_destroy: bool
+            sse_kms_key_id: Optional[str]
+            name: str = None
+            _hidden = ["name"]
+            _no_doc = True
 
-    buckets: Dict[str, Bucket]
-    monitoring_bucket: Optional[Bucket]
+        blobs: Bucket
+        logs: Bucket
+        backups: Bucket
+        registry: Bucket
+        monitoring: Bucket
+        _no_doc = True
+
+        @classmethod
+        def load(cls, buckets: Dict[str, Bucket]):
+            def _bucket(b: dict) -> S3.BucketList.Bucket:
+                if not b:
+                    return
+                b_out = S3.BucketList.Bucket(
+                    auto_delete_objects=b.pop("auto_delete_objects", False),
+                    removal_policy_destroy=b.pop("removal_policy_destroy", False),
+                    sse_kms_key_id=b.pop("sse_kms_key_id", None),
+                    name=b.pop("name", None),
+                )
+                check_leavins("s3 bucket attribute", "config.s3.buckets.bucket", b)
+                return b_out
+
+            out = cls(
+                blobs=_bucket(buckets.pop("blobs")),
+                logs=_bucket(buckets.pop("logs")),
+                backups=_bucket(buckets.pop("backups")),
+                registry=_bucket(buckets.pop("registry")),
+                monitoring=_bucket(buckets.pop("monitoring", None)),
+            )
+            check_leavins("s3 bucket", "config.s3.buckets", buckets)
+            return out
+
+    buckets: BucketList
 
     @staticmethod
     def from_0_0_0(c: dict):
-        def _bucket(b: dict) -> S3.Bucket:
-            return S3.Bucket(
-                auto_delete_objects=b.pop("auto_delete_objects", False),
-                removal_policy_destroy=b.pop("removal_policy_destroy", False),
-                sse_kms_key_id=b.pop("sse_kms_key_id", None),
-            )
-
-        buckets = c.pop("buckets")
-        monitoring_bucket = c.pop("monitoring_bucket", None)
         return from_loader(
             "config.s3",
             S3(
-                buckets={name: _bucket(b) for name, b in buckets.items()},
-                monitoring_bucket=_bucket(monitoring_bucket) if monitoring_bucket else None,
+                buckets=S3.BucketList.load(c.pop("buckets"))
             ),
             c,
         )

--- a/cdk/domino_cdk/config/s3.py
+++ b/cdk/domino_cdk/config/s3.py
@@ -42,7 +42,7 @@ class S3:
         @classmethod
         def load(cls, buckets: Dict[str, Bucket]):
             def _bucket(b: dict) -> S3.BucketList.Bucket:
-                if not b:
+                if b is None:
                     return
                 b_out = S3.BucketList.Bucket(
                     auto_delete_objects=b.pop("auto_delete_objects", False),
@@ -62,6 +62,16 @@ class S3:
             )
             check_leavins("s3 bucket", "config.s3.buckets", buckets)
             return out
+
+        def __post_init__(self):
+            errors = []
+
+            for b in ["blobs", "logs", "backups", "registry"]:
+                if not getattr(self, b):
+                    errors.append(f"Error: No definition for {b} bucket")
+
+            if errors:
+                raise ValueError(errors)
 
     buckets: BucketList
 

--- a/cdk/domino_cdk/config/s3.py
+++ b/cdk/domino_cdk/config/s3.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from os import getenv
 from typing import Dict, Optional
 
 from domino_cdk.config.util import check_leavins, from_loader
@@ -38,6 +39,7 @@ class S3:
         registry: Bucket
         monitoring: Bucket
         _no_doc = True
+        _testing = False
 
         @classmethod
         def load(cls, buckets: Dict[str, Bucket]):
@@ -70,7 +72,7 @@ class S3:
                 if not getattr(self, b):
                     errors.append(f"Error: No definition for {b} bucket")
 
-            if errors:
+            if errors and not getenv("SKIP_UNDEFINED_BUCKETS"):
                 raise ValueError(errors)
 
     buckets: BucketList

--- a/cdk/domino_cdk/config/template.py
+++ b/cdk/domino_cdk/config/template.py
@@ -131,27 +131,25 @@ def config_template(
     route53 = Route53(zone_ids=[])
 
     s3 = S3(
-        buckets={
-            'blobs': S3.Bucket(
+        buckets=S3.BucketList(
+            blobs=S3.BucketList.Bucket(
                 auto_delete_objects=destroy_on_destroy, removal_policy_destroy=destroy_on_destroy, sse_kms_key_id=None
             ),
-            'logs': S3.Bucket(
+            logs=S3.BucketList.Bucket(
                 auto_delete_objects=destroy_on_destroy, removal_policy_destroy=destroy_on_destroy, sse_kms_key_id=None
             ),
-            'backups': S3.Bucket(
+            backups=S3.BucketList.Bucket(
                 auto_delete_objects=destroy_on_destroy, removal_policy_destroy=destroy_on_destroy, sse_kms_key_id=None
             ),
-            'registry': S3.Bucket(
+            registry=S3.BucketList.Bucket(
                 auto_delete_objects=destroy_on_destroy, removal_policy_destroy=destroy_on_destroy, sse_kms_key_id=None
             ),
-        },
-        monitoring_bucket=S3.Bucket(
-            auto_delete_objects=destroy_on_destroy,
-            removal_policy_destroy=destroy_on_destroy,
-            sse_kms_key_id=None,
+            monitoring=S3.BucketList.Bucket(
+                auto_delete_objects=destroy_on_destroy,
+                removal_policy_destroy=destroy_on_destroy,
+                sse_kms_key_id=None,
+            ) if not disable_flow_logs else None
         )
-        if not disable_flow_logs
-        else None,
     )
 
     overrides: Dict[Any, Any] = {}

--- a/cdk/domino_cdk/config/template.py
+++ b/cdk/domino_cdk/config/template.py
@@ -148,7 +148,9 @@ def config_template(
                 auto_delete_objects=destroy_on_destroy,
                 removal_policy_destroy=destroy_on_destroy,
                 sse_kms_key_id=None,
-            ) if not disable_flow_logs else None
+            )
+            if not disable_flow_logs
+            else None,
         )
     )
 

--- a/cdk/domino_cdk/provisioners/s3.py
+++ b/cdk/domino_cdk/provisioners/s3.py
@@ -136,7 +136,8 @@ class DominoS3Provisioner:
 
         self.buckets = {
             bucket: self._provision_bucket(stack_name, bucket, attrs, server_access_logs_bucket=self.monitoring_bucket)
-            for bucket, attrs in vars(s3.buckets).items() if attrs and bucket != "monitoring"  # skipping NoneType bucket is for tests, config prevents loading
+            for bucket, attrs in vars(s3.buckets).items()
+            if attrs and bucket != "monitoring"  # skipping NoneType bucket is for tests, config prevents loading
         }
 
         for bucket_id, bucket in self.buckets.items():

--- a/cdk/tests/unit/config/__init__.py
+++ b/cdk/tests/unit/config/__init__.py
@@ -117,13 +117,23 @@ default_config = DominoCDKConfig(
         secrets_encryption_key_arn=None,
     ),
     s3=S3(
-        buckets={
-            'blobs': S3.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
-            'logs': S3.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
-            'backups': S3.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
-            'registry': S3.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
-        },
-        monitoring_bucket=S3.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
+        buckets=S3.BucketList(
+            blobs=S3.BucketList.Bucket(
+                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
+            ),
+            logs=S3.BucketList.Bucket(
+                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
+            ),
+            backups=S3.BucketList.Bucket(
+                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
+            ),
+            registry=S3.BucketList.Bucket(
+                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
+            ),
+            monitoring=S3.BucketList.Bucket(
+                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
+            )
+        )
     ),
     schema='0.0.1-rc5',
 )
@@ -307,13 +317,21 @@ legacy_config = DominoCDKConfig(
         secrets_encryption_key_arn=None,
     ),
     s3=S3(
-        buckets={
-            'blobs': S3.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
-            'logs': S3.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
-            'backups': S3.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
-            'registry': S3.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
-        },
-        monitoring_bucket=None,
+        buckets=S3.BucketList(
+            blobs=S3.BucketList.Bucket(
+                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
+            ),
+            logs=S3.BucketList.Bucket(
+                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
+            ),
+            backups=S3.BucketList.Bucket(
+                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
+            ),
+            registry=S3.BucketList.Bucket(
+                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
+            ),
+            monitoring=None,
+        ),
     ),
     schema='0.0.1-rc5',
 )

--- a/cdk/tests/unit/config/__init__.py
+++ b/cdk/tests/unit/config/__init__.py
@@ -118,21 +118,13 @@ default_config = DominoCDKConfig(
     ),
     s3=S3(
         buckets=S3.BucketList(
-            blobs=S3.BucketList.Bucket(
-                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
-            ),
-            logs=S3.BucketList.Bucket(
-                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
-            ),
-            backups=S3.BucketList.Bucket(
-                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
-            ),
-            registry=S3.BucketList.Bucket(
-                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
-            ),
+            blobs=S3.BucketList.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
+            logs=S3.BucketList.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
+            backups=S3.BucketList.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
+            registry=S3.BucketList.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
             monitoring=S3.BucketList.Bucket(
                 auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
-            )
+            ),
         )
     ),
     schema='0.0.1-rc5',
@@ -318,18 +310,10 @@ legacy_config = DominoCDKConfig(
     ),
     s3=S3(
         buckets=S3.BucketList(
-            blobs=S3.BucketList.Bucket(
-                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
-            ),
-            logs=S3.BucketList.Bucket(
-                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
-            ),
-            backups=S3.BucketList.Bucket(
-                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
-            ),
-            registry=S3.BucketList.Bucket(
-                auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None
-            ),
+            blobs=S3.BucketList.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
+            logs=S3.BucketList.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
+            backups=S3.BucketList.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
+            registry=S3.BucketList.Bucket(auto_delete_objects=False, removal_policy_destroy=False, sse_kms_key_id=None),
             monitoring=None,
         ),
     ),

--- a/cdk/tests/unit/config/__init__.py
+++ b/cdk/tests/unit/config/__init__.py
@@ -127,7 +127,7 @@ default_config = DominoCDKConfig(
             ),
         )
     ),
-    schema='0.0.1-rc5',
+    schema='0.0.1',
 )
 
 legacy_template = {
@@ -317,7 +317,7 @@ legacy_config = DominoCDKConfig(
             monitoring=None,
         ),
     ),
-    schema='0.0.1-rc5',
+    schema='0.0.1',
 )
 
 

--- a/cdk/tests/unit/config/test_config.py
+++ b/cdk/tests/unit/config/test_config.py
@@ -74,12 +74,9 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(c.efs.backup.removal_policy, "DESTROY")
         self.assertTrue(c.efs.removal_policy_destroy)
 
-        for b in c.s3.buckets.values():
+        for b in vars(c.s3.buckets).values():
             self.assertTrue(b.auto_delete_objects)
             self.assertTrue(b.removal_policy_destroy)
-
-        self.assertTrue(c.s3.monitoring_bucket.auto_delete_objects)
-        self.assertTrue(c.s3.monitoring_bucket.removal_policy_destroy)
 
         self.assertEqual(
             c.install.overrides,

--- a/cdk/tests/unit/config/test_s3.py
+++ b/cdk/tests/unit/config/test_s3.py
@@ -27,6 +27,11 @@ s3_0_0_0_cfg = {
             "removal_policy_destroy": True,
             "sse_kms_key_id": sse_kms_key_id,
         },
+        "monitoring": {
+            "auto_delete_objects": True,
+            "removal_policy_destroy": True,
+            "sse_kms_key_id": sse_kms_key_id,
+        },
     }
 }
 
@@ -51,19 +56,25 @@ s3_obj = S3(
 
 class TestConfigS3(unittest.TestCase):
     def test_from_0_0_0(self):
-        return True
         s3 = S3.from_0_0_0(deepcopy(s3_0_0_0_cfg))
         self.assertEqual(s3, s3_obj)
 
-    def test_all_defaults(self):
-        return True
+    def test_bucket_defaults(self):
         s3_cfg = deepcopy(s3_0_0_0_cfg)
-        s3_cfg["buckets"]["bucket1"] = {}
+        s3_cfg["buckets"]["blobs"] = {}
+        s3_cfg["buckets"]["monitoring"] = None
         s3_obj_defaults = deepcopy(s3_obj)
-        s3_obj_defaults.buckets["bucket1"] = S3.Bucket(False, False, None)
+        s3_obj_defaults.buckets.blobs = S3.BucketList.Bucket(False, False, None, None)
+        s3_obj_defaults.buckets.monitoring = None
         s3 = S3.from_0_0_0(s3_cfg)
         self.assertEqual(s3, s3_obj_defaults)
 
     def test_no_buckets(self):
-        return True
-        self.assertEqual(S3.from_0_0_0({"buckets": {}}), S3(buckets={}, monitoring_bucket=None))
+        s3_cfg = deepcopy(s3_0_0_0_cfg)
+        s3_cfg["buckets"]["blobs"] = None
+        s3_cfg["buckets"]["logs"] = None
+        s3_cfg["buckets"]["backups"] = None
+        s3_cfg["buckets"]["registry"] = None
+
+        with self.assertRaisesRegex(ValueError, "No definition for blobs.*logs.*backups.*registry bucket"):
+            S3.from_0_0_0(s3_cfg)

--- a/cdk/tests/unit/config/test_s3.py
+++ b/cdk/tests/unit/config/test_s3.py
@@ -31,24 +31,22 @@ s3_0_0_0_cfg = {
 }
 
 s3_obj = S3(
-        buckets=S3.BucketList(
-            blobs=S3.BucketList.Bucket(
-                auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
-            ),
-            logs=S3.BucketList.Bucket(
-                auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
-            ),
-            backups=S3.BucketList.Bucket(
-                auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
-            ),
-            registry=S3.BucketList.Bucket(
-                auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
-            ),
-            monitoring=S3.BucketList.Bucket(
-                auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
-            )
-        )
+    buckets=S3.BucketList(
+        blobs=S3.BucketList.Bucket(
+            auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
+        ),
+        logs=S3.BucketList.Bucket(auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id),
+        backups=S3.BucketList.Bucket(
+            auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
+        ),
+        registry=S3.BucketList.Bucket(
+            auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
+        ),
+        monitoring=S3.BucketList.Bucket(
+            auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
+        ),
     )
+)
 
 
 class TestConfigS3(unittest.TestCase):

--- a/cdk/tests/unit/config/test_s3.py
+++ b/cdk/tests/unit/config/test_s3.py
@@ -7,12 +7,22 @@ sse_kms_key_id = "some-kms-key"
 
 s3_0_0_0_cfg = {
     "buckets": {
-        "bucket1": {
+        "blobs": {
             "auto_delete_objects": True,
             "removal_policy_destroy": True,
             "sse_kms_key_id": sse_kms_key_id,
         },
-        "bucket2": {
+        "logs": {
+            "auto_delete_objects": True,
+            "removal_policy_destroy": True,
+            "sse_kms_key_id": sse_kms_key_id,
+        },
+        "backups": {
+            "auto_delete_objects": True,
+            "removal_policy_destroy": True,
+            "sse_kms_key_id": sse_kms_key_id,
+        },
+        "registry": {
             "auto_delete_objects": True,
             "removal_policy_destroy": True,
             "sse_kms_key_id": sse_kms_key_id,
@@ -21,17 +31,34 @@ s3_0_0_0_cfg = {
 }
 
 s3_obj = S3(
-    buckets={"bucket1": S3.Bucket(True, True, sse_kms_key_id), "bucket2": S3.Bucket(True, True, sse_kms_key_id)},
-    monitoring_bucket=None,
-)
+        buckets=S3.BucketList(
+            blobs=S3.BucketList.Bucket(
+                auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
+            ),
+            logs=S3.BucketList.Bucket(
+                auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
+            ),
+            backups=S3.BucketList.Bucket(
+                auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
+            ),
+            registry=S3.BucketList.Bucket(
+                auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
+            ),
+            monitoring=S3.BucketList.Bucket(
+                auto_delete_objects=True, removal_policy_destroy=True, sse_kms_key_id=sse_kms_key_id
+            )
+        )
+    )
 
 
 class TestConfigS3(unittest.TestCase):
     def test_from_0_0_0(self):
+        return True
         s3 = S3.from_0_0_0(deepcopy(s3_0_0_0_cfg))
         self.assertEqual(s3, s3_obj)
 
     def test_all_defaults(self):
+        return True
         s3_cfg = deepcopy(s3_0_0_0_cfg)
         s3_cfg["buckets"]["bucket1"] = {}
         s3_obj_defaults = deepcopy(s3_obj)
@@ -40,4 +67,5 @@ class TestConfigS3(unittest.TestCase):
         self.assertEqual(s3, s3_obj_defaults)
 
     def test_no_buckets(self):
+        return True
         self.assertEqual(S3.from_0_0_0({"buckets": {}}), S3(buckets={}, monitoring_bucket=None))

--- a/cdk/tests/unit/provisioners/test_s3.py
+++ b/cdk/tests/unit/provisioners/test_s3.py
@@ -16,8 +16,13 @@ class TestDominoS3Provisioner(TestCase):
 
     def test_monitoring_bucket(self):
         s3_config = S3(
-            buckets={},
-            monitoring_bucket=S3.Bucket(True, True, ""),
+            buckets=S3.BucketList(
+                blobs=None,
+                logs=None,
+                backups=None,
+                registry=None,
+                monitoring=S3.BucketList.Bucket(True, True, "")
+            )
         )
 
         DominoS3Provisioner(self.stack, "construct-1", "test-s3", s3_config, False)
@@ -90,8 +95,13 @@ class TestDominoS3Provisioner(TestCase):
 
     def test_monitoring_kms_key(self):
         s3_config = S3(
-            buckets={},
-            monitoring_bucket=S3.Bucket(True, True, self.KMS_KEY_ARN),
+            buckets=S3.BucketList(
+                blobs=None,
+                logs=None,
+                backups=None,
+                registry=None,
+                monitoring=S3.BucketList.Bucket(True, True, self.KMS_KEY_ARN)
+            )
         )
 
         DominoS3Provisioner(self.stack, "construct-1", "test-s3", s3_config, False)
@@ -120,7 +130,7 @@ class TestDominoS3Provisioner(TestCase):
         buckets = [
             (
                 "retain",
-                S3.Bucket(False, False, ""),
+                S3.BucketList.Bucket(False, False, "", "test-s3-retain"),
                 {
                     "Properties": {
                         "BucketName": "test-s3-retain",
@@ -143,7 +153,7 @@ class TestDominoS3Provisioner(TestCase):
             ),
             (
                 "cmk",
-                S3.Bucket(False, False, self.KMS_KEY_ARN),
+                S3.BucketList.Bucket(False, False, self.KMS_KEY_ARN, "test-s3-cmk"),
                 {
                     "Properties": {
                         "BucketName": "test-s3-cmk",
@@ -172,7 +182,7 @@ class TestDominoS3Provisioner(TestCase):
             ),
             (
                 "destroy",
-                S3.Bucket(True, True, ""),
+                S3.BucketList.Bucket(True, True, "", "test-s3-destroy"),
                 {
                     "Properties": {
                         "BucketName": "test-s3-destroy",
@@ -204,8 +214,13 @@ class TestDominoS3Provisioner(TestCase):
             stack = Stack(app, "S3", env=Environment(region="us-west-2"))
 
             s3_config = S3(
-                buckets={name: bucket},
-                monitoring_bucket=None,
+                buckets=S3.BucketList(
+                    blobs=bucket,
+                    logs=None,
+                    backups=None,
+                    registry=None,
+                    monitoring=None,
+                )
             )
 
             DominoS3Provisioner(stack, "construct-1", "test-s3", s3_config, False)
@@ -253,8 +268,13 @@ class TestDominoS3Provisioner(TestCase):
 
     def test_buckets_access_logging(self):
         s3_config = S3(
-            buckets={"logged": S3.Bucket(False, False, "")},
-            monitoring_bucket=S3.Bucket(False, False, ""),
+            buckets=S3.BucketList(
+                blobs=None,
+                logs=S3.BucketList.Bucket(False, False, ""),
+                registry=None,
+                backups=None,
+                monitoring=S3.BucketList.Bucket(False, False, ""),
+            )
         )
 
         DominoS3Provisioner(self.stack, "construct-1", "test-s3", s3_config, False)
@@ -271,10 +291,10 @@ class TestDominoS3Provisioner(TestCase):
         assertion.has_resource_properties(
             "AWS::S3::Bucket",
             {
-                "BucketName": "test-s3-logged",
+                "BucketName": "test-s3-logs",
                 "LoggingConfiguration": {
                     "DestinationBucketName": {"Ref": "monitoringF4BD3810"},
-                    "LogFilePrefix": "test-s3-logged/",
+                    "LogFilePrefix": "test-s3-logs/",
                 },
             },
         )

--- a/cdk/tests/unit/provisioners/test_s3.py
+++ b/cdk/tests/unit/provisioners/test_s3.py
@@ -17,11 +17,7 @@ class TestDominoS3Provisioner(TestCase):
     def test_monitoring_bucket(self):
         s3_config = S3(
             buckets=S3.BucketList(
-                blobs=None,
-                logs=None,
-                backups=None,
-                registry=None,
-                monitoring=S3.BucketList.Bucket(True, True, "")
+                blobs=None, logs=None, backups=None, registry=None, monitoring=S3.BucketList.Bucket(True, True, "")
             )
         )
 
@@ -100,7 +96,7 @@ class TestDominoS3Provisioner(TestCase):
                 logs=None,
                 backups=None,
                 registry=None,
-                monitoring=S3.BucketList.Bucket(True, True, self.KMS_KEY_ARN)
+                monitoring=S3.BucketList.Bucket(True, True, self.KMS_KEY_ARN),
             )
         )
 

--- a/cdk/tests/unit/provisioners/test_s3.py
+++ b/cdk/tests/unit/provisioners/test_s3.py
@@ -1,3 +1,5 @@
+from os import environ
+
 from aws_cdk.assertions import TemplateAssertions
 from aws_cdk.core import App, Environment, Stack
 
@@ -13,6 +15,7 @@ class TestDominoS3Provisioner(TestCase):
     def setUp(self):
         self.app = App()
         self.stack = Stack(self.app, "S3", env=Environment(region="us-west-2"))
+        environ["SKIP_UNDEFINED_BUCKETS"] = "True"
 
     def test_monitoring_bucket(self):
         s3_config = S3(
@@ -294,3 +297,7 @@ class TestDominoS3Provisioner(TestCase):
                 },
             },
         )
+
+    @classmethod
+    def teardown_class(cls):
+        del environ["SKIP_UNDEFINED_BUCKETS"]

--- a/cdk/util.py
+++ b/cdk/util.py
@@ -7,14 +7,13 @@ from sys import stdout
 from ruamel.yaml import YAML, SafeLoader
 from ruamel.yaml import load as yaml_load
 
+from domino_cdk import __version__
 from domino_cdk.config import config_loader
 from domino_cdk.config.iam import generate_iam
 from domino_cdk.config.template import config_template
 from domino_cdk.util import DominoCdkUtil
 
-DEFAULT_TF_MODULE_PATH = (
-    "https://github.com/dominodatalab/cdk-cf-eks/releases/download/v0.0.1rc2/domino-cdk-terraform-0.0.1-rc2.tar.gz"
-)
+DEFAULT_TF_MODULE_PATH = f"https://github.com/dominodatalab/cdk-cf-eks/releases/download/v{__version__}/domino-cdk-terraform-{__version__}.tar.gz"
 
 
 def parse_args():


### PR DESCRIPTION
* Make it so that bucket _types_ are statically configured
* Adds an option to modify the bucket name in case we need to
* Adds a feature to make certain config values hidden
* Makes the bucket name override hidden so we don't clutter the config
* Removes the `-rcX` suffix from the version in code, since CI takes care of that for us now