### PR TITLE
PLAT-37: Install coredns/kube-proxy/vpc-cni addons

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
+import boto3
 from aws_cdk import core
 from ruamel.yaml import SafeLoader
 from ruamel.yaml import load as yaml_load
 
 from domino_cdk.config import config_loader
 from domino_cdk.domino_stack import DominoStack
+
+sts = boto3.client("sts")
+try:
+    sts.get_caller_identity()
+except Exception:
+    print("WARNING: Domino CDK App requires valid AWS credentials!\n")
+    raise
+
 
 app = core.App()
 

--- a/cdk/domino_cdk/aws_configurator.py
+++ b/cdk/domino_cdk/aws_configurator.py
@@ -25,7 +25,6 @@ class DominoAwsConfigurator:
         self.eks_cluster = eks_cluster
 
         self.install_calico()
-        self.patch_vpc_cni_selinux()
 
     def install_calico(self):
         # This produces an obnoxious diff on every subsequent run
@@ -60,15 +59,3 @@ class DominoAwsConfigurator:
                 manifest=[notcrd for notcrd in loaded_manifests if notcrd["kind"] != "CustomResourceDefinition"],
             )
             non_crds.node.add_dependency(crds)
-
-    # Until https://github.com/aws/amazon-vpc-cni-k8s/issues/1291 is resolved
-    def patch_vpc_cni_selinux(self):
-        eks.KubernetesPatch(
-            self.scope,
-            "vpc-cni-selinux",
-            cluster=self.eks_cluster,
-            resource_name="daemonset/aws-node",
-            resource_namespace="kube-system",
-            apply_patch={"spec": {"template": {"spec": {"securityContext": {"seLinuxOptions": {"type": "spc_t"}}}}}},
-            restore_patch={},
-        )

--- a/cdk/domino_cdk/provisioners/eks/eks_cluster.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_cluster.py
@@ -112,6 +112,32 @@ class DominoEksClusterProvisioner:
                 ),
             )
 
+        self.setup_addons(cluster, eks_version.version)
+
+        return cluster
+
+    def setup_addons(self, cluster: eks.Cluster, eks_version: str) -> eks.CfnAddon:
+        def addon(addon: str) -> eks.CfnAddon:
+            if not self._addon_cache:
+                eks_client = boto3.client("eks", self.scope.region)
+                result = eks_client.describe_addon_versions(kubernetesVersion=eks_version)
+                self._addon_cache = {a["addonName"]: a for a in result["addons"]}
+
+            versions = [v["addonVersion"] for v in self._addon_cache[addon]["addonVersions"]]
+
+            return eks.CfnAddon(
+                self.scope,
+                addon,
+                addon_name=addon,
+                cluster_name=cluster.cluster_name,
+                resolve_conflicts="OVERWRITE",
+                addon_version=sorted(versions)[-1],
+            )
+
+        vpc_cni_addon = addon("vpc-cni")
+        addon("coredns")
+        addon("kube-proxy")
+
         # Until https://github.com/aws/amazon-vpc-cni-k8s/issues/1291 is resolved
         patch = eks.KubernetesPatch(
             self.scope,
@@ -123,25 +149,4 @@ class DominoEksClusterProvisioner:
             restore_patch={},
         )
 
-        patch.node.add_dependency(self.addon("vpc-cni", cluster.cluster_name, eks_version.version))
-        self.addon("coredns", cluster.cluster_name, eks_version.version)
-        self.addon("kube-proxy", cluster.cluster_name, eks_version.version)
-
-        return cluster
-
-    def addon(self, addon: str, cluster_name: str, eks_version: str) -> eks.CfnAddon:
-        if not self._addon_cache:
-            eks_client = boto3.client("eks", self.scope.region)
-            result = eks_client.describe_addon_versions(kubernetesVersion=eks_version)
-            self._addon_cache = {a["addonName"]: a for a in result["addons"]}
-
-        versions = [v["addonVersion"] for v in self._addon_cache[addon]["addonVersions"]]
-
-        return eks.CfnAddon(
-            self.scope,
-            addon,
-            addon_name=addon,
-            cluster_name=cluster_name,
-            resolve_conflicts="OVERWRITE",
-            addon_version=sorted(versions)[-1],
-        )
+        patch.node.add_dependency(vpc_cni_addon)

--- a/cdk/domino_cdk/provisioners/eks/eks_cluster.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_cluster.py
@@ -145,9 +145,6 @@ class DominoEksClusterProvisioner:
             result = eks.describe_addon_versions(kubernetesVersion=eks_version.version)
             self._addon_cache = {a["addonName"]: a for a in result["addons"]}
 
-        versions = [
-            v["addonVersion"]
-            for v in self._addon_cache[addon]["addonVersions"]
-        ]
+        versions = [v["addonVersion"] for v in self._addon_cache[addon]["addonVersions"]]
 
         return sorted(versions)[-1]

--- a/cdk/domino_cdk/provisioners/eks/eks_cluster.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_cluster.py
@@ -142,13 +142,12 @@ class DominoEksClusterProvisioner:
     def addon_version(self, addon: str, eks_version: str):
         if not self._addon_cache:
             eks = boto3.client("eks", self.scope.region)
-            result = eks.describe_addon_versions()
+            result = eks.describe_addon_versions(kubernetesVersion=eks_version.version)
             self._addon_cache = {a["addonName"]: a for a in result["addons"]}
 
         versions = [
             v["addonVersion"]
             for v in self._addon_cache[addon]["addonVersions"]
-            if eks_version.version in [c["clusterVersion"] for c in v["compatibilities"]]
         ]
 
         return sorted(versions)[-1]

--- a/cdk/setup.py
+++ b/cdk/setup.py
@@ -38,6 +38,7 @@ setuptools.setup(
         "aws-cdk.core~=1.110.1",
         "aws-cdk.lambda-layer-awscli~=1.110.1",
         "aws-cdk.lambda-layer-kubectl~=1.110.1",
+        "boto3~=1.18.7",
         "field_properties~=0.1",
         "requests~=2.25.1",
         "ruamel.yaml~=0.17.7",

--- a/cdk/tests/unit/provisioners/test_aws_configurator.py
+++ b/cdk/tests/unit/provisioners/test_aws_configurator.py
@@ -57,7 +57,7 @@ class TestDominoAwsConfigurator(TestCase):
         self.assertEqual(len(loads(noncrds_resource["Properties"]["Manifest"])), 1)
 
     def test_patch_vpc_cni_selinux(self):
-        return True # TODO: move this elsewhere
+        return True  # TODO: move this elsewhere
         DominoAwsConfigurator(self.stack, self.eks_cluster)
 
         assertion = TemplateAssertions.from_stack(self.stack)

--- a/cdk/tests/unit/provisioners/test_aws_configurator.py
+++ b/cdk/tests/unit/provisioners/test_aws_configurator.py
@@ -55,22 +55,3 @@ class TestDominoAwsConfigurator(TestCase):
             res for name, res in template["Resources"].items() if name.startswith("calico") and res != crds_resource
         )
         self.assertEqual(len(loads(noncrds_resource["Properties"]["Manifest"])), 1)
-
-    def test_patch_vpc_cni_selinux(self):
-        return True  # TODO: move this elsewhere
-        DominoAwsConfigurator(self.stack, self.eks_cluster)
-
-        assertion = TemplateAssertions.from_stack(self.stack)
-        assertion.resource_count_is("Custom::AWSCDK-EKS-KubernetesPatch", 1)
-
-        template = self.app.synth().get_stack("calico").template
-        patch = self.find_resource(template, "Custom::AWSCDK-EKS-KubernetesPatch")
-        properties = patch["Properties"]
-
-        self.assertEqual("daemonset/aws-node", properties["ResourceName"])
-        self.assertEqual(
-            {"spec": {"template": {"spec": {"securityContext": {"seLinuxOptions": {"type": "spc_t"}}}}}},
-            loads(properties["ApplyPatchJson"]),
-        )
-        self.assertEqual("{}", properties["RestorePatchJson"])
-        self.assertEqual("strategic", properties["PatchType"])

--- a/cdk/tests/unit/provisioners/test_aws_configurator.py
+++ b/cdk/tests/unit/provisioners/test_aws_configurator.py
@@ -57,6 +57,7 @@ class TestDominoAwsConfigurator(TestCase):
         self.assertEqual(len(loads(noncrds_resource["Properties"]["Manifest"])), 1)
 
     def test_patch_vpc_cni_selinux(self):
+        return True # TODO: move this elsewhere
         DominoAwsConfigurator(self.stack, self.eks_cluster)
 
         assertion = TemplateAssertions.from_stack(self.stack)

--- a/cdk/tests/unit/provisioners/test_eks_cluster.py
+++ b/cdk/tests/unit/provisioners/test_eks_cluster.py
@@ -1,0 +1,44 @@
+from json import loads
+
+import aws_cdk.aws_eks as eks
+from aws_cdk.assertions import TemplateAssertions
+from aws_cdk.core import App, Environment, Stack
+
+from domino_cdk.provisioners.eks import DominoEksClusterProvisioner
+
+from . import TestCase
+
+STACK_NAME = "DominoCDK"
+
+
+class TestEksClusterProvisioner(TestCase):
+    def setUp(self):
+        self.app = App()
+        self.stack = Stack(self.app, STACK_NAME, env=Environment(region="us-west-2"))
+        self.eks_version = eks.KubernetesVersion.V1_20
+        self.eks_cluster = eks.Cluster(self.stack, "eks", version=self.eks_version)
+
+    def test_setup_addons(self):
+        eks_provisioner = DominoEksClusterProvisioner(self.stack)
+
+        eks_provisioner.setup_addons(self.eks_cluster, self.eks_version.version)
+
+        assertion = TemplateAssertions.from_stack(self.stack)
+        assertion.resource_count_is("Custom::AWSCDK-EKS-KubernetesPatch", 1)
+        assertion.resource_count_is("AWS::EKS::Addon", 3)
+        assertion.has_resource_properties("AWS::EKS::Addon", {"AddonName": "vpc-cni"})
+        assertion.has_resource_properties("AWS::EKS::Addon", {"AddonName": "kube-proxy"})
+        assertion.has_resource_properties("AWS::EKS::Addon", {"AddonName": "coredns"})
+
+        template = self.app.synth().get_stack(STACK_NAME).template
+
+        patch = self.find_resource(template, "Custom::AWSCDK-EKS-KubernetesPatch")
+        properties = patch["Properties"]
+
+        self.assertEqual("daemonset/aws-node", properties["ResourceName"])
+        self.assertEqual(
+            {"spec": {"template": {"spec": {"securityContext": {"seLinuxOptions": {"type": "spc_t"}}}}}},
+            loads(properties["ApplyPatchJson"]),
+        )
+        self.assertEqual("{}", properties["RestorePatchJson"])
+        self.assertEqual("strategic", properties["PatchType"])


### PR DESCRIPTION
* Install coredns, kube-proxy and vpc-cni as "EKS addons"
  * These are all installed by default, but unmanaged
  * On EKS upgrades, these services won't get upgraded unless they're managed as addons
* Uses boto3 to get the most current version of any given addon
  * You can leave the version field blank, but it won't get updated
  * There is no "use the latest" function in cloudformation/cdk
  * Have an alternate version that uses 3 (!!!) custom resources instead of boto3: https://github.com/dominodatalab/cdk-cf-eks/pull/62
    * The CRs just feel too icky to me........
    * But somebody tell me if I should just give in and do them........ ugh.
* Adds new runtime requirement of valid aws creds for aws synth, which was only required for deploy previously