### PR TITLE
Temp revert helm version removal comments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,6 @@ on:
 jobs:
   test-build-deploy:
     runs-on: ubuntu-latest
-    env:
-      DEPLOYER_IMAGE: quay.io/domino/deployer:develop.82257b0469580769a4a8243401f300eab6a7cf03
     defaults:
       run:
         working-directory: ./cdk
@@ -101,7 +99,7 @@ jobs:
       run: |
         $(jq -r ".[].ekskubeconfigcmd" outputs.json) --kubeconfig ./kubeconfig
         jq -r ".[].agentconfig" outputs.json > agent_template.yaml
-        docker run --rm -v $(pwd):/cdk $DEPLOYER_IMAGE python -m fleetcommand_agent init --full -t /cdk/agent_template.yaml -f /cdk/domino.yml
+        docker run --rm -v $(pwd):/cdk quay.io/domino/deployer:v42 python -m fleetcommand_agent init --full -t /cdk/agent_template.yaml -f /cdk/domino.yml
     - name: Install Domino
       if: contains(github.event.pull_request.labels.*.name, 'deploy-test') || github.ref == 'refs/heads/master'
       env:
@@ -110,7 +108,7 @@ jobs:
         KUBECONFIG: ./kubeconfig
         LOG_DIR: k8s-cluster-state
       run: |
-        docker run --rm -v $(pwd):/cdk -v $(pwd)/agent_logs:/domino-deployer/logs -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e KUBECONFIG=/cdk/kubeconfig $DEPLOYER_IMAGE python -m fleetcommand_agent run -f /cdk/domino.yml
+        docker run --rm -v $(pwd):/cdk -v $(pwd)/agent_logs:/domino-deployer/logs -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e KUBECONFIG=/cdk/kubeconfig quay.io/domino/deployer:v42 python -m fleetcommand_agent run -f /cdk/domino.yml
     - name: Collect diagnostic data
       if: always() && (contains(github.event.pull_request.labels.*.name, 'deploy-test') || github.ref == 'refs/heads/master')
       env:
@@ -146,7 +144,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_ACCESS_KEY }}
       run: |
-        docker run --rm -v $(pwd):/cdk -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e KUBECONFIG=/cdk/kubeconfig $DEPLOYER_IMAGE python -m fleetcommand_agent destroy -f /cdk/domino.yml
+        docker run --rm -v $(pwd):/cdk -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e KUBECONFIG=/cdk/kubeconfig quay.io/domino/deployer:v42 python -m fleetcommand_agent destroy -f /cdk/domino.yml
     - name: Destroy CDK
       if: always() && (contains(github.event.pull_request.labels.*.name, 'deploy-test') || github.ref == 'refs/heads/master')
       env:

--- a/cdk/domino_cdk/agent.py
+++ b/cdk/domino_cdk/agent.py
@@ -76,6 +76,7 @@ def generate_install_config(
         },
         "gpu": {"enabled": True},
         "helm": {
+            "version": 3,
             "cache_path": "charts",
         },
         "services": {

--- a/cdk/domino_cdk/config/iam.py
+++ b/cdk/domino_cdk/config/iam.py
@@ -342,6 +342,7 @@ def generate_iam(stack_name: str, aws_account_id: str, region: str, manual: bool
             "ec2:ModifyInstanceMetadataOptions",
             "ec2:ReleaseAddress",
             "ec2:RunInstances",
+            "eks:*Addon*",
             "eks:CreateNodegroup",
             "eks:DeleteNodegroup",
             "eks:DescribeNodegroup",


### PR DESCRIPTION
Intent is to do a final release of domino-cdk 0.0.1 to go
along with the next platform-apps release, but the helm
version change isn't going to be in the platform-apps release,
so removing that change from the branch long enough to do
the cdk release.

Reversion info:

Revert "PLAT-428: Update deployer image from platform-apps"

This reverts commit 30f8912f9217a71cb04b037ff0c542f5b708b7c8.

Revert "PLAT-428: Temporary deployer image"

This reverts commit 0177802c9b0f013b7d2f53b584411f944e4d9d19.

Revert "PLAT-428: Remove helm version"

This reverts commit 44c30e0453d30a9c738e753216e846e105420235.