### PR TITLE
Add EKS addon support to manual/terraform IAM perms

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
+import boto3
 from aws_cdk import core
 from ruamel.yaml import SafeLoader
 from ruamel.yaml import load as yaml_load
 
 from domino_cdk.config import config_loader
 from domino_cdk.domino_stack import DominoStack
+
+sts = boto3.client("sts")
+try:
+    sts.get_caller_identity()
+except Exception:
+    print("WARNING: Domino CDK App requires valid AWS credentials!\n")
+    raise
+
 
 app = core.App()
 

--- a/cdk/domino_cdk/aws_configurator.py
+++ b/cdk/domino_cdk/aws_configurator.py
@@ -25,7 +25,6 @@ class DominoAwsConfigurator:
         self.eks_cluster = eks_cluster
 
         self.install_calico()
-        self.patch_vpc_cni_selinux()
 
     def install_calico(self):
         # This produces an obnoxious diff on every subsequent run
@@ -60,15 +59,3 @@ class DominoAwsConfigurator:
                 manifest=[notcrd for notcrd in loaded_manifests if notcrd["kind"] != "CustomResourceDefinition"],
             )
             non_crds.node.add_dependency(crds)
-
-    # Until https://github.com/aws/amazon-vpc-cni-k8s/issues/1291 is resolved
-    def patch_vpc_cni_selinux(self):
-        eks.KubernetesPatch(
-            self.scope,
-            "vpc-cni-selinux",
-            cluster=self.eks_cluster,
-            resource_name="daemonset/aws-node",
-            resource_namespace="kube-system",
-            apply_patch={"spec": {"template": {"spec": {"securityContext": {"seLinuxOptions": {"type": "spc_t"}}}}}},
-            restore_patch={},
-        )

--- a/cdk/domino_cdk/config/iam.py
+++ b/cdk/domino_cdk/config/iam.py
@@ -342,6 +342,7 @@ def generate_iam(stack_name: str, aws_account_id: str, region: str, manual: bool
             "ec2:ModifyInstanceMetadataOptions",
             "ec2:ReleaseAddress",
             "ec2:RunInstances",
+            "eks:*Addon*",
             "eks:CreateNodegroup",
             "eks:DeleteNodegroup",
             "eks:DescribeNodegroup",

--- a/cdk/setup.py
+++ b/cdk/setup.py
@@ -38,6 +38,7 @@ setuptools.setup(
         "aws-cdk.core~=1.110.1",
         "aws-cdk.lambda-layer-awscli~=1.110.1",
         "aws-cdk.lambda-layer-kubectl~=1.110.1",
+        "boto3~=1.18.7",
         "field_properties~=0.1",
         "requests~=2.25.1",
         "ruamel.yaml~=0.17.7",

--- a/cdk/tests/unit/provisioners/test_aws_configurator.py
+++ b/cdk/tests/unit/provisioners/test_aws_configurator.py
@@ -55,21 +55,3 @@ class TestDominoAwsConfigurator(TestCase):
             res for name, res in template["Resources"].items() if name.startswith("calico") and res != crds_resource
         )
         self.assertEqual(len(loads(noncrds_resource["Properties"]["Manifest"])), 1)
-
-    def test_patch_vpc_cni_selinux(self):
-        DominoAwsConfigurator(self.stack, self.eks_cluster)
-
-        assertion = TemplateAssertions.from_stack(self.stack)
-        assertion.resource_count_is("Custom::AWSCDK-EKS-KubernetesPatch", 1)
-
-        template = self.app.synth().get_stack("calico").template
-        patch = self.find_resource(template, "Custom::AWSCDK-EKS-KubernetesPatch")
-        properties = patch["Properties"]
-
-        self.assertEqual("daemonset/aws-node", properties["ResourceName"])
-        self.assertEqual(
-            {"spec": {"template": {"spec": {"securityContext": {"seLinuxOptions": {"type": "spc_t"}}}}}},
-            loads(properties["ApplyPatchJson"]),
-        )
-        self.assertEqual("{}", properties["RestorePatchJson"])
-        self.assertEqual("strategic", properties["PatchType"])

--- a/cdk/tests/unit/provisioners/test_eks_cluster.py
+++ b/cdk/tests/unit/provisioners/test_eks_cluster.py
@@ -1,0 +1,49 @@
+from json import loads
+from unittest.mock import patch
+
+import aws_cdk.aws_eks as eks
+from aws_cdk.assertions import TemplateAssertions
+from aws_cdk.core import App, Environment, Stack
+
+from domino_cdk.provisioners.eks import DominoEksClusterProvisioner
+
+from . import TestCase
+
+STACK_NAME = "DominoCDK"
+ADDON_VERSION = "1.2.3-x.y.z"
+
+
+class TestEksClusterProvisioner(TestCase):
+    def setUp(self):
+        self.app = App()
+        self.stack = Stack(self.app, STACK_NAME, env=Environment(region="us-west-2"))
+        self.eks_version = eks.KubernetesVersion.V1_20
+        self.eks_cluster = eks.Cluster(self.stack, "eks", version=self.eks_version)
+
+    @patch("domino_cdk.provisioners.eks.DominoEksClusterProvisioner._get_addon_version")
+    def test_setup_addons(self, mock_get_addon_version):
+        mock_get_addon_version.return_value = ADDON_VERSION
+
+        eks_provisioner = DominoEksClusterProvisioner(self.stack)
+
+        eks_provisioner.setup_addons(self.eks_cluster, self.eks_version.version)
+
+        assertion = TemplateAssertions.from_stack(self.stack)
+        assertion.resource_count_is("Custom::AWSCDK-EKS-KubernetesPatch", 1)
+        assertion.resource_count_is("AWS::EKS::Addon", 3)
+        assertion.has_resource_properties("AWS::EKS::Addon", {"AddonName": "vpc-cni", "AddonVersion": ADDON_VERSION})
+        assertion.has_resource_properties("AWS::EKS::Addon", {"AddonName": "kube-proxy", "AddonVersion": ADDON_VERSION})
+        assertion.has_resource_properties("AWS::EKS::Addon", {"AddonName": "coredns", "AddonVersion": ADDON_VERSION})
+
+        template = self.app.synth().get_stack(STACK_NAME).template
+
+        k8s_patch = self.find_resource(template, "Custom::AWSCDK-EKS-KubernetesPatch")
+        properties = k8s_patch["Properties"]
+
+        self.assertEqual("daemonset/aws-node", properties["ResourceName"])
+        self.assertEqual(
+            {"spec": {"template": {"spec": {"securityContext": {"seLinuxOptions": {"type": "spc_t"}}}}}},
+            loads(properties["ApplyPatchJson"]),
+        )
+        self.assertEqual("{}", properties["RestorePatchJson"])
+        self.assertEqual("strategic", properties["PatchType"])


### PR DESCRIPTION
These IAM policy bits were missed when merging the addon support.

No CDK changes, and want this in the release, so turbomerging.