### PR TITLE
PLAT-2497: Tag untaggable things

### DIFF
--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -28,6 +28,9 @@ class DominoStack(cdk.Stack):
         self.env = kwargs["env"]
         self.name = self.cfg.name
         cdk.CfnOutput(self, "deploy_name", value=self.name)
+
+        self.untagged_resources = {"ec2": [], "iam": []}
+
         for k, v in self.cfg.tags.items():
             cdk.Tags.of(self).add(str(k), str(v))
 
@@ -69,7 +72,7 @@ class DominoStack(cdk.Stack):
             scope=self,
             stack_name=self.name,
             name="fix_missing_tags",
-            properties={"stack_name": self.name, "tags": self.cfg.tags, "vpc_id": self.vpc_stack.vpc.vpc_id, "boing": "boom"},
+            properties={"stack_name": self.name, "tags": self.cfg.tags, "vpc_id": self.vpc_stack.vpc.vpc_id, "untagged_resources": self.untagged_resources, "boing": "boom"},
             resources=[
                 f"arn:{partition}:ec2:{self.region}:{self.account}:vpc/{self.vpc_stack.vpc.vpc_id}",
                 f"arn:{partition}:ec2:{self.region}:{self.account}:vpc-endpoint/*",

--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -1,5 +1,4 @@
 from aws_cdk import core as cdk
-from aws_cdk.region_info import Fact, FactName
 
 from domino_cdk.agent import generate_install_config
 from domino_cdk.aws_configurator import DominoAwsConfigurator
@@ -67,7 +66,6 @@ class DominoStack(cdk.Stack):
             nest,
         )
 
-        partition = Fact.require_fact(self.region, FactName.PARTITION)
         create_lambda(
             scope=self,
             stack_name=self.name,
@@ -77,11 +75,8 @@ class DominoStack(cdk.Stack):
                 "tags": self.cfg.tags,
                 "vpc_id": self.vpc_stack.vpc.vpc_id,
                 "untagged_resources": self.untagged_resources,
-                "boing": "boom",
             },
             resources=[
-                f"arn:{partition}:ec2:{self.region}:{self.account}:vpc/{self.vpc_stack.vpc.vpc_id}",
-                f"arn:{partition}:ec2:{self.region}:{self.account}:vpc-endpoint/*",
                 "*",
             ],
             actions=[

--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -13,8 +13,8 @@ from domino_cdk.provisioners import (
 from domino_cdk.provisioners.eks.eks_iam_roles_for_k8s import (
     DominoEksK8sIamRolesProvisioner,
 )
-from domino_cdk.util import DominoCdkUtil
 from domino_cdk.provisioners.lambda_utils import create_lambda
+from domino_cdk.util import DominoCdkUtil
 
 
 class DominoStack(cdk.Stack):
@@ -72,7 +72,13 @@ class DominoStack(cdk.Stack):
             scope=self,
             stack_name=self.name,
             name="fix_missing_tags",
-            properties={"stack_name": self.name, "tags": self.cfg.tags, "vpc_id": self.vpc_stack.vpc.vpc_id, "untagged_resources": self.untagged_resources, "boing": "boom"},
+            properties={
+                "stack_name": self.name,
+                "tags": self.cfg.tags,
+                "vpc_id": self.vpc_stack.vpc.vpc_id,
+                "untagged_resources": self.untagged_resources,
+                "boing": "boom",
+            },
             resources=[
                 f"arn:{partition}:ec2:{self.region}:{self.account}:vpc/{self.vpc_stack.vpc.vpc_id}",
                 f"arn:{partition}:ec2:{self.region}:{self.account}:vpc-endpoint/*",

--- a/cdk/domino_cdk/provisioners/eks/__init__.py
+++ b/cdk/domino_cdk/provisioners/eks/__init__.py
@@ -29,6 +29,8 @@ class DominoEksProvisioner:
     ) -> None:
         self.scope = cdk.NestedStack(parent, construct_id, **kwargs) if nest else parent
 
+        self.scope.untagged_resources = parent.untagged_resources
+
         eks_version = getattr(eks.KubernetesVersion, f"V{eks_cfg.version.replace('.', '_')}")
 
         self.cluster = DominoEksClusterProvisioner(self.scope).provision(

--- a/cdk/domino_cdk/provisioners/eks/eks_iam.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam.py
@@ -93,11 +93,17 @@ class DominoEksIamProvisioner:
             iam.ManagedPolicy.from_aws_managed_policy_name('AmazonSSMManagedInstanceCore'),
         ]
 
+        self.scope.untagged_resources["iam"].extend([ecr_policy.managed_policy_arn, autoscaler_policy.managed_policy_arn, snapshot_policy.managed_policy_arn])
+
         if r53_zone_ids:
-            managed_policies.append(self.provision_r53_policy(stack_name, r53_zone_ids))
+            r53_policy = self.provision_r53_policy(stack_name, r53_zone_ids)
+            managed_policies.append(r53_policy)
+            self.scope.untagged_resources["iam"].append(r53_policy.managed_policy_arn)
 
         if buckets:
-            managed_policies.append(self.provision_node_s3_iam_policy(stack_name, buckets))
+            s3_policy = self.provision_node_s3_iam_policy(stack_name, buckets)
+            managed_policies.append(s3_policy)
+            self.scope.untagged_resources["iam"].append(s3_policy.managed_policy_arn)
 
         return iam.Role(
             self.scope,

--- a/cdk/domino_cdk/provisioners/eks/eks_iam.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam.py
@@ -93,7 +93,9 @@ class DominoEksIamProvisioner:
             iam.ManagedPolicy.from_aws_managed_policy_name('AmazonSSMManagedInstanceCore'),
         ]
 
-        self.scope.untagged_resources["iam"].extend([ecr_policy.managed_policy_arn, autoscaler_policy.managed_policy_arn, snapshot_policy.managed_policy_arn])
+        self.scope.untagged_resources["iam"].extend(
+            [ecr_policy.managed_policy_arn, autoscaler_policy.managed_policy_arn, snapshot_policy.managed_policy_arn]
+        )
 
         if r53_zone_ids:
             r53_policy = self.provision_r53_policy(stack_name, r53_zone_ids)

--- a/cdk/domino_cdk/provisioners/eks/eks_iam_roles_for_k8s.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam_roles_for_k8s.py
@@ -107,7 +107,9 @@ class DominoEksK8sIamRolesProvisioner:
 
         managed_policies.update(self.create_s3_policies(stack_name, buckets))
 
-        self.scope.untagged_resources["iam"].extend([policy.managed_policy_arn for category in managed_policies.values() for policy in category.values()])
+        self.scope.untagged_resources["iam"].extend(
+            [policy.managed_policy_arn for category in managed_policies.values() for policy in category.values()]
+        )
 
         for name, policy_ref in roles.items():
             iam_role = iam.Role(

--- a/cdk/domino_cdk/provisioners/eks/eks_iam_roles_for_k8s.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam_roles_for_k8s.py
@@ -107,6 +107,8 @@ class DominoEksK8sIamRolesProvisioner:
 
         managed_policies.update(self.create_s3_policies(stack_name, buckets))
 
+        self.scope.untagged_resources["iam"].extend([policy.managed_policy_arn for category in managed_policies.values() for policy in category.values()])
+
         for name, policy_ref in roles.items():
             iam_role = iam.Role(
                 self.scope,

--- a/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
@@ -65,6 +65,7 @@ class DominoEksNodegroupProvisioner:
             machine_image=machine_image,
             user_data=mime_user_data,
         )
+        self.scope.untagged_resources["ec2"].append(lt.launch_template_id)
         lts = eks.LaunchTemplateSpec(id=lt.launch_template_id, version=lt.version_number)
 
         for i, az in enumerate(self.vpc.availability_zones[:max_nodegroup_azs]):
@@ -186,6 +187,8 @@ class DominoEksNodegroupProvisioner:
                     ),
                 )
                 cfn_lt.launch_template_data = lt_data
+
+            self.scope.untagged_resources["ec2"].append(cfn_lt.ref)
 
             # https://github.com/aws/aws-cdk/issues/6734
             cfn_asg: aws_autoscaling.CfnAutoScalingGroup = asg.node.default_child

--- a/cdk/domino_cdk/provisioners/lambda_files/fix_missing_tags.py
+++ b/cdk/domino_cdk/provisioners/lambda_files/fix_missing_tags.py
@@ -1,0 +1,86 @@
+import json
+import os
+import traceback
+
+import boto3
+import requests
+
+
+def on_event(event, context):
+    print('Debug: event: ', event)
+    print('Debug: environ:', os.environ)
+    request_type = event['RequestType']
+    response = {}
+    try:
+        if request_type == 'Create':
+            response = on_create(event)
+        if request_type == 'Update':
+            response = on_update(event)
+        if response:
+            event.update(response)
+        event['Status'] = 'SUCCESS'
+    except:  # noqa: E722
+        traceback.print_exc()
+        event['Status'] = 'FAILED'
+    requests.put(event['ResponseURL'], data=json.dumps(event))
+
+
+def tag_ec2(tags, stack_name, vpc_id):
+    print("Tagging stuff!")
+    resource_ids = []
+
+    client = boto3.client("ec2")
+    vpc_filter = [{"Name": "vpc-id", "Values": [vpc_id]}]
+
+    endpoints = client.describe_vpc_endpoints(Filters=vpc_filter)
+    resource_ids.extend([ep["VpcEndpointId"] for ep in endpoints["VpcEndpoints"]])
+
+    route_tables = client.describe_route_tables(Filters=vpc_filter)
+    resource_ids.extend([rt["RouteTableId"] for rt in route_tables["RouteTables"]])
+    # If we want to restrict to the default one, we could do:
+    # [rt for rt in rts if not rt["Tags"]] or search for main one
+
+    security_groups = client.describe_security_groups(Filters=[*vpc_filter, {"Name": "group-name", "Values": ["default"]}])
+    resource_ids.append(security_groups["SecurityGroups"][0]["GroupId"])
+
+    network_acls = client.describe_network_acls(Filters=vpc_filter)
+    resource_ids.extend([acl["NetworkAclId"] for acl in network_acls["NetworkAcls"]])
+
+    # "Our" Launch Templates either have our deploy name in their name, or have a basic eks cluster tag with the deploy name
+    # Potentially just have CDK pass these?
+    launch_templates = client.describe_launch_templates()
+    our_lts = [lt for lt in launch_templates["LaunchTemplates"] if stack_name in lt['LaunchTemplateName'] or stack_name in [v["Value"] for v in lt.get("Tags", [])]]
+    resource_ids.extend([lt["LaunchTemplateId"] for lt in our_lts])
+
+    print(resource_ids)
+
+    client.create_tags(Resources=resource_ids, Tags=tags)
+
+
+def tag_iam(tags, stack_name):
+    client = boto3.client("iam")
+
+    # Similarly to launch templates, could we just have cdk give us these?
+    policy_arns = [p["Arn"] for p in client.list_policies()["Policies"] if stack_name in p["PolicyName"]]
+    for arn in policy_arns:
+        client.tag_policy(PolicyArn=arn, Tags=tags)
+
+
+def tag_stuff(event):
+    tags = [{"Key": k, "Value": v} for k, v in event['ResourceProperties']['tags'].items()]
+    stack_name = event["ResourceProperties"]["stack_name"]
+    vpc_id = event['ResourceProperties']['vpc_id']
+
+    tag_ec2(tags, stack_name, vpc_id)
+    tag_iam(tags, stack_name)
+
+
+def on_update(event):
+    tag_stuff(event)
+
+
+def on_create(event):
+    tag_stuff(event)
+
+    physical_id = f'domino-tag-fixer-{event["ResourceProperties"]["stack_name"]}'
+    return {'PhysicalResourceId': physical_id}

--- a/cdk/domino_cdk/provisioners/lambda_files/fix_missing_tags.py
+++ b/cdk/domino_cdk/provisioners/lambda_files/fix_missing_tags.py
@@ -25,9 +25,8 @@ def on_event(event, context):
     requests.put(event['ResponseURL'], data=json.dumps(event))
 
 
-def tag_ec2(tags, stack_name, vpc_id):
+def tag_ec2(tags, stack_name, vpc_id, resource_ids):
     print("Tagging stuff!")
-    resource_ids = []
 
     client = boto3.client("ec2")
     vpc_filter = [{"Name": "vpc-id", "Values": [vpc_id]}]
@@ -46,23 +45,17 @@ def tag_ec2(tags, stack_name, vpc_id):
     network_acls = client.describe_network_acls(Filters=vpc_filter)
     resource_ids.extend([acl["NetworkAclId"] for acl in network_acls["NetworkAcls"]])
 
-    # "Our" Launch Templates either have our deploy name in their name, or have a basic eks cluster tag with the deploy name
-    # Potentially just have CDK pass these?
-    launch_templates = client.describe_launch_templates()
-    our_lts = [lt for lt in launch_templates["LaunchTemplates"] if stack_name in lt['LaunchTemplateName'] or stack_name in [v["Value"] for v in lt.get("Tags", [])]]
-    resource_ids.extend([lt["LaunchTemplateId"] for lt in our_lts])
-
     print(resource_ids)
 
     client.create_tags(Resources=resource_ids, Tags=tags)
 
 
-def tag_iam(tags, stack_name):
+def tag_iam(tags, stack_name, resource_arns):
     client = boto3.client("iam")
 
-    # Similarly to launch templates, could we just have cdk give us these?
-    policy_arns = [p["Arn"] for p in client.list_policies()["Policies"] if stack_name in p["PolicyName"]]
-    for arn in policy_arns:
+    print(f"IAM resources to tag: {resource_arns}")
+
+    for arn in resource_arns:
         client.tag_policy(PolicyArn=arn, Tags=tags)
 
 
@@ -70,9 +63,10 @@ def tag_stuff(event):
     tags = [{"Key": k, "Value": v} for k, v in event['ResourceProperties']['tags'].items()]
     stack_name = event["ResourceProperties"]["stack_name"]
     vpc_id = event['ResourceProperties']['vpc_id']
+    untagged_resources = event["ResourceProperties"]["untagged_resources"]
 
-    tag_ec2(tags, stack_name, vpc_id)
-    tag_iam(tags, stack_name)
+    tag_ec2(tags, stack_name, vpc_id, untagged_resources["ec2"])
+    tag_iam(tags, stack_name, untagged_resources["iam"])
 
 
 def on_update(event):

--- a/cdk/domino_cdk/provisioners/lambda_files/fix_missing_tags.py
+++ b/cdk/domino_cdk/provisioners/lambda_files/fix_missing_tags.py
@@ -39,7 +39,9 @@ def tag_ec2(tags, stack_name, vpc_id, resource_ids):
     # If we want to restrict to the default one, we could do:
     # [rt for rt in rts if not rt["Tags"]] or search for main one
 
-    security_groups = client.describe_security_groups(Filters=[*vpc_filter, {"Name": "group-name", "Values": ["default"]}])
+    security_groups = client.describe_security_groups(
+        Filters=[*vpc_filter, {"Name": "group-name", "Values": ["default"]}]
+    )
     resource_ids.append(security_groups["SecurityGroups"][0]["GroupId"])
 
     network_acls = client.describe_network_acls(Filters=vpc_filter)


### PR DESCRIPTION
There are a few items that get created which aren't automatically tagged, nor are directly taggable with CDK.

This creates a consolidated tagger for these missing items.