### PR TITLE
PLAT-3733: Update IAM perms & add disable rollback feature to terraform

### DIFF
--- a/cdk/domino_cdk/config/iam.py
+++ b/cdk/domino_cdk/config/iam.py
@@ -390,11 +390,7 @@ def generate_iam(stack_name: str, aws_account_id: str, region: str, manual: bool
                 "ec2:DeleteRouteTable",
                 "ec2:DeleteVpc",
                 "ec2:DeleteVpcEndpoints",
-                "ec2:DescribeInternetGateways",
-                "ec2:DescribeNatGateways",
-                "ec2:DescribeRouteTables",
-                "ec2:DescribeVpcEndpoints",
-                "ec2:DescribeVpcs",
+                "ec2:Describe*",
                 "ec2:DetachInternetGateway",
                 "ec2:DisAssociateRouteTable",
                 "ec2:DisassociateVpcCidrBlock",
@@ -411,6 +407,7 @@ def generate_iam(stack_name: str, aws_account_id: str, region: str, manual: bool
     else:
         general["Action"].extend(
             [
+                "ec2:Describe*",
                 "ec2:*InternetGateway*",
                 "ec2:*NatGateway*",
                 "ec2:*Route*",

--- a/cdk/domino_cdk/util.py
+++ b/cdk/domino_cdk/util.py
@@ -68,6 +68,7 @@ class DominoCdkUtil:
         disable_random_templates: bool = False,
         iam_role_arn: str = "",
         iam_policy_paths: List[str] = None,
+        disable_rollback: bool = False,
     ):
         cfg = cls.load_manifest(path_join(asset_dir, "manifest.json"))
         stack_name = cfg["name"]
@@ -107,6 +108,7 @@ class DominoCdkUtil:
                     "name": stack_name,
                     "iam_role_arn": iam_role_arn,
                     "iam_policy_paths": iam_policy_paths,
+                    "disable_rollback": disable_rollback,
                     "parameters": asset_parameters,
                     "template_filename": basename(template_filename),
                     "output_dir": output_dir,

--- a/cdk/util.py
+++ b/cdk/util.py
@@ -140,6 +140,11 @@ def parse_args():
         action="append",
         default=[],
     )
+    tf_bootstrap_parser.add_argument(
+        "--disable-rollback",
+        help="Disable rollback on stack provisioniong failures",
+        action="store_true",
+    )
     tf_bootstrap_parser.set_defaults(func=generate_terraform_bootstrap)
 
     args = parser.parse_args()
@@ -227,6 +232,7 @@ def generate_terraform_bootstrap(args):
                 args.disable_random_templates,
                 args.iam_role_arn,
                 args.iam_policy_path,
+                args.disable_rollback,
             ),
             indent=4,
         )

--- a/terraform/cloudformation.tf
+++ b/terraform/cloudformation.tf
@@ -9,6 +9,7 @@ resource "aws_cloudformation_stack" "cdk_stack" {
   iam_role_arn       = length(var.iam_policy_paths) != 0 ? aws_iam_role.deployment[0].arn : var.iam_role_arn
   depends_on         = [aws_s3_bucket_object.assets]
   timeout_in_minutes = var.cloudformation_timeout_in_minutes
+  disable_rollback = var.disable_rollback
 
   timeouts {
     create = "${var.cloudformation_timeout_in_minutes}m"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,6 +28,11 @@ variable "parameters" {
   description = "Parameters to feed into cloudformation"
 }
 
+variable "disable_rollback" {
+  type        = bool
+  description = "Disable rollback on stack provisioniong failures"
+}
+
 variable "template_filename" {
   type        = string
   description = "Filename of CloudFormation Template file in asset_dir (usually <stack_name>.template.json)"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,6 +31,7 @@ variable "parameters" {
 variable "disable_rollback" {
   type        = bool
   description = "Disable rollback on stack provisioniong failures"
+  default     = false
 }
 
 variable "template_filename" {


### PR DESCRIPTION
* We seem to need the ability to describe nacls for some reason now
  * Let's just `Describe*` and simplify it
* Make "disable rollback" configurable for troubleshooting / preferences
  * Should this be the default, given the way we typically work? Currently still non-default...