### PR TITLE
PLAT-3779: Add DescribeInstanceStatus IAM policy

### DIFF
--- a/cdk/domino_cdk/config/iam.py
+++ b/cdk/domino_cdk/config/iam.py
@@ -338,6 +338,7 @@ def generate_iam(stack_name: str, aws_account_id: str, region: str, manual: bool
             "ec2:DescribeAvailabilityZones",
             "ec2:DescribeImages",
             "ec2:DescribeInstances",
+            "ec2:DescribeInstanceStatus",
             "ec2:DescribeLaunchTemplates",
             "ec2:DescribeSecurityGroups",
             "ec2:DisassociateAddress",

--- a/cdk/domino_cdk/config/iam.py
+++ b/cdk/domino_cdk/config/iam.py
@@ -338,7 +338,6 @@ def generate_iam(stack_name: str, aws_account_id: str, region: str, manual: bool
             "ec2:DescribeAvailabilityZones",
             "ec2:DescribeImages",
             "ec2:DescribeInstances",
-            "ec2:DescribeInstanceStatus",
             "ec2:DescribeLaunchTemplates",
             "ec2:DescribeSecurityGroups",
             "ec2:DisassociateAddress",

--- a/cdk/domino_cdk/provisioners/eks/eks_iam.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam.py
@@ -91,6 +91,7 @@ class DominoEksIamProvisioner:
                     actions=[
                         "ec2:DescribeAvailabilityZones",
                         "ec2:DescribeInstances",
+                        "ec2:DescribeInstanceStatus",
                         "ec2:DescribeSnapshots",
                         "ec2:DescribeTags",
                         "ec2:DescribeVolumes",

--- a/cdk/domino_cdk/provisioners/eks/eks_iam.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_iam.py
@@ -91,7 +91,6 @@ class DominoEksIamProvisioner:
                     actions=[
                         "ec2:DescribeAvailabilityZones",
                         "ec2:DescribeInstances",
-                        "ec2:DescribeInstanceStatus",
                         "ec2:DescribeSnapshots",
                         "ec2:DescribeTags",
                         "ec2:DescribeVolumes",


### PR DESCRIPTION
### Link to JIRA

[PLAT-3779](https://dominodatalab.atlassian.net/browse/PLAT-3779)

### What issue does this pull request solve?

Adds `DescribeInstanceStatus` IAM policy to EC2 instances which is needed for [Shoreline](https://shoreline.io/)