### PR TITLE
PLAT-2892: Add perms to create service linked role for ASG + bastion eip fix w/ec2 classic

### DIFF
--- a/cdk/domino_cdk/config/iam.py
+++ b/cdk/domino_cdk/config/iam.py
@@ -80,6 +80,7 @@ def generate_iam(stack_name: str, aws_account_id: str, region: str, manual: bool
             "iam:CreatePolicy",
             "iam:CreatePolicyVersion",
             "iam:CreateRole",
+            "iam:CreateServiceLinkedRole",
             "iam:DeleteInstanceProfile",
             "iam:DeletePolicy",
             "iam:DeletePolicyVersion",
@@ -100,6 +101,7 @@ def generate_iam(stack_name: str, aws_account_id: str, region: str, manual: bool
             f"arn:{partition}:iam::{aws_account_id}:policy/{stack_name}-*",
             f"arn:{partition}:iam::{aws_account_id}:role/{stack_name}-*",
             f"arn:{partition}:iam::{aws_account_id}:instance-profile/{stack_name}-*",
+            f"arn:{partition}:iam::{aws_account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
         ],
     }
 

--- a/cdk/domino_cdk/provisioners/vpc.py
+++ b/cdk/domino_cdk/provisioners/vpc.py
@@ -254,6 +254,7 @@ class DominoVpcProvisioner:
         ec2.CfnEIP(
             self.scope,
             "bastion_eip",
+            domain="vpc",
             instance_id=bastion_instance.instance_id,
         )
 


### PR DESCRIPTION
* Accounts that have never used ASGs before require extra perms to create a service linked role used with ASGs
  * Added perms
* In situations where EC2 classic is still available (noticed in cloud-prod account), elastic ips created in CDK will default to ec2 classic EIPs instead of regular VPC ips.
  * Explicitly define our bastion EIP to be a VPC EIP so this floating default can't cause problems.