### PR TITLE
PLAT-4675 Platform min_size to 3 on dev env

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,7 +130,7 @@ jobs:
         LOG_DIR: k8s-cluster-state
       run: |
         set +e
-        curl -Lo /usr/local/bin/kubectl  "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        curl -Lo /usr/local/bin/kubectl  "https://dl.k8s.io/release/v1.23.6//bin/linux/amd64/kubectl"
         for ns in domino-platform domino-compute domino-system kube-system; do
           mkdir -p $LOG_DIR/$ns
           kubectl -n $ns get ing -o yaml > $LOG_DIR/$ns/ingress.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,6 +130,7 @@ jobs:
         LOG_DIR: k8s-cluster-state
       run: |
         set +e
+        curl -Lo /usr/local/bin/kubectl  "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
         for ns in domino-platform domino-compute domino-system kube-system; do
           mkdir -p $LOG_DIR/$ns
           kubectl -n $ns get ing -o yaml > $LOG_DIR/$ns/ingress.txt

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ cdk.context.json
 
 # terraform
 terraform/.terraform
+
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cdk.context.json
 terraform/.terraform
 
 .idea/
+.coverage

--- a/cdk/domino_cdk/config/template.py
+++ b/cdk/domino_cdk/config/template.py
@@ -39,7 +39,6 @@ def config_template(
     destroy_on_destroy = True if dev_defaults else False
     disk_size = 100 if dev_defaults else 1000
     platform_instance_type = "m5.4xlarge" if dev_defaults or istio_compatible else "m5.2xlarge"
-    platform_min_size = 3 if dev_defaults else 1
 
     unmanaged_nodegroups = {}
 
@@ -76,7 +75,7 @@ def config_template(
     add_nodegroups(
         "platform",
         platform_nodegroups,
-        platform_min_size,
+        3,
         [platform_instance_type],
         {"dominodatalab.com/node-pool": "platform"},
     )

--- a/cdk/domino_cdk/config/template.py
+++ b/cdk/domino_cdk/config/template.py
@@ -39,6 +39,7 @@ def config_template(
     destroy_on_destroy = True if dev_defaults else False
     disk_size = 100 if dev_defaults else 1000
     platform_instance_type = "m5.4xlarge" if dev_defaults or istio_compatible else "m5.2xlarge"
+    platform_min_size = 3 if dev_defaults else 1
 
     unmanaged_nodegroups = {}
 
@@ -75,7 +76,7 @@ def config_template(
     add_nodegroups(
         "platform",
         platform_nodegroups,
-        1,
+        platform_min_size,
         [platform_instance_type],
         {"dominodatalab.com/node-pool": "platform"},
     )

--- a/cdk/tests/unit/config/__init__.py
+++ b/cdk/tests/unit/config/__init__.py
@@ -68,7 +68,7 @@ default_config = DominoCDKConfig(
             'platform-0': EKS.UnmanagedNodegroup(
                 disk_size=100,
                 key_name=None,
-                min_size=1,
+                min_size=3,
                 max_size=10,
                 availability_zones=None,
                 ami_id=None,


### PR DESCRIPTION
Set min_size for platform environment to 3 so scale up/down do not affect selenium tests. It will also keep a good size in for new development needs