### PR TITLE
Set dev to 3 nodes via nodegroup az count instead

### DIFF
--- a/cdk/domino_cdk/config/template.py
+++ b/cdk/domino_cdk/config/template.py
@@ -35,7 +35,6 @@ def config_template(
 ):
     fill = "__FILL__"
 
-    max_nodegroup_azs = 1 if dev_defaults else 3
     destroy_on_destroy = True if dev_defaults else False
     disk_size = 100 if dev_defaults else 1000
     platform_instance_type = "m5.4xlarge" if dev_defaults or istio_compatible else "m5.2xlarge"
@@ -75,7 +74,7 @@ def config_template(
     add_nodegroups(
         "platform",
         platform_nodegroups,
-        3,
+        1,
         [platform_instance_type],
         {"dominodatalab.com/node-pool": "platform"},
     )
@@ -133,7 +132,7 @@ def config_template(
         version="1.21",
         private_api=private_api,
         secrets_encryption_key_arn=secrets_encryption_key_arn,
-        max_nodegroup_azs=max_nodegroup_azs,
+        max_nodegroup_azs=3,
         global_node_labels={'dominodatalab.com/domino-node': 'true'},
         global_node_tags={},
         managed_nodegroups={},

--- a/cdk/tests/unit/config/__init__.py
+++ b/cdk/tests/unit/config/__init__.py
@@ -68,7 +68,7 @@ default_config = DominoCDKConfig(
             'platform-0': EKS.UnmanagedNodegroup(
                 disk_size=100,
                 key_name=None,
-                min_size=3,
+                min_size=1,
                 max_size=10,
                 availability_zones=None,
                 ami_id=None,

--- a/cdk/tests/unit/config/test_config.py
+++ b/cdk/tests/unit/config/test_config.py
@@ -121,7 +121,6 @@ class TestConfig(unittest.TestCase):
 
     def test_dev(self):
         c = config_template(dev_defaults=True)
-        self.assertEqual(c.eks.max_nodegroup_azs, 1)
         self.assertEqual(["m5.4xlarge"], c.eks.unmanaged_nodegroups["platform-0"].instance_types)
         for ng in c.eks.unmanaged_nodegroups.values():
             self.assertEqual(ng.disk_size, 100)


### PR DESCRIPTION
We tried to set platform node count to match dev defaults, but didn't account for the multiple nodegroups.