### PR TITLE
Add lifecycle ignore rule to disable_rollback

### DIFF
--- a/terraform/cloudformation.tf
+++ b/terraform/cloudformation.tf
@@ -18,6 +18,10 @@ resource "aws_cloudformation_stack" "cdk_stack" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [disable_rollback]
+  }
 }
 
 output "cloudformation_outputs" {


### PR DESCRIPTION
Because this totally sucks:

```
-/+ resource "aws_cloudformation_stack" "cdk_stack" {
      ~ disable_rollback   = false -> true # forces replacement
```