### PR TITLE
DOM-37779: Add tag to connect asg to ebs zones

### DIFF
--- a/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
@@ -85,7 +85,10 @@ class DominoEksNodegroupProvisioner:
                 instance_types=[ec2.InstanceType(it) for it in ng.instance_types],
                 launch_template_spec=lts,
                 labels=ng.labels,
-                tags=ng.tags,
+                tags= {
+                    **ng.tags,
+                    "k8s.io/cluster-autoscaler/node-template/label/topology.ebs.csi.aws.com/zone": az,
+                },
                 node_role=self.ng_role,
             )
 
@@ -156,6 +159,7 @@ class DominoEksNodegroupProvisioner:
                     **{
                         f"k8s.io/cluster-autoscaler/{self.cluster.cluster_name}": "owned",
                         "k8s.io/cluster-autoscaler/enabled": "true",
+                        "k8s.io/cluster-autoscaler/node-template/label/topology.ebs.csi.aws.com/zone": az,
                         "eks:cluster-name": self.cluster.cluster_name,
                         "Name": indexed_name,
                     },

--- a/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
@@ -85,7 +85,7 @@ class DominoEksNodegroupProvisioner:
                 instance_types=[ec2.InstanceType(it) for it in ng.instance_types],
                 launch_template_spec=lts,
                 labels=ng.labels,
-                tags= {
+                tags={
                     **ng.tags,
                     "k8s.io/cluster-autoscaler/node-template/label/topology.ebs.csi.aws.com/zone": az,
                 },


### PR DESCRIPTION
We've encountered problems scaling pods from zero when they use a PVC that's still associated with a node that was previously in the nodegroup and the cluster-autoscaler doesn't have an in-memory cache that the ASG would be able to fulfil it.

There is a tag we can add so the cluster-autoscaler can determine this, so add that.

See: https://github.com/kubernetes/autoscaler/issues/3845