### PR TITLE
HBD-186: Introduce configuration fields to disable resources which aren't needed for data plane

### DIFF
--- a/cdk/domino_cdk/config/base.py
+++ b/cdk/domino_cdk/config/base.py
@@ -35,7 +35,7 @@ class DominoCDKConfig:
 
     vpc: VPC = None
     efs: Optional[EFS] = None
-    route53: Route53 = None
+    route53: Route53 = Optional[None]
     eks: EKS = None
     s3: Optional[S3] = None
 
@@ -54,6 +54,22 @@ class DominoCDKConfig:
 
     @staticmethod
     def from_0_0_0(c: dict):
+        s3 = None
+        if cfg := c.pop("s3", None):
+            s3 = S3.from_0_0_0(cfg)
+
+        route53 = None
+        if cfg := c.pop("route53", None):
+            route53 = Route53.from_0_0_0(cfg)
+
+        efs = None
+        if cfg := c.pop("efs", None):
+            route53 = EFS.from_0_0_0(cfg)
+
+        install = None
+        if cfg := c.pop("install", None):
+            install = Install.from_0_0_0(cfg)
+
         return from_loader(
             "config",
             DominoCDKConfig(
@@ -64,17 +80,33 @@ class DominoCDKConfig:
                 tags=c.pop("tags", {}),
                 create_iam_roles_for_service_accounts=False,
                 vpc=VPC.from_0_0_0({**c.pop("vpc"), **{"availability_zones": c.pop("availability_zones", [])}}),
-                efs=EFS.from_0_0_0(c.pop("efs")),
-                route53=Route53.from_0_0_0(c.pop("route53")),
+                efs=efs,
+                route53=route53,
                 eks=EKS.from_0_0_0(c.pop("eks")),
-                s3=S3.from_0_0_0(c.pop("s3")),
-                install=Install.from_0_0_0(c.pop("install")),
+                s3=s3,
+                install=install,
             ),
             c,
         )
 
     @staticmethod
     def from_0_0_1(c: dict):
+        s3 = None
+        if cfg := c.pop("s3", None):
+            s3 = S3.from_0_0_0(cfg)
+
+        route53 = None
+        if cfg := c.pop("route53", None):
+            route53 = Route53.from_0_0_0(cfg)
+
+        efs = None
+        if cfg := c.pop("efs", None):
+            route53 = EFS.from_0_0_0(cfg)
+
+        install = None
+        if cfg := c.pop("install", None):
+            install = Install.from_0_0_1(cfg)
+
         return from_loader(
             "config",
             DominoCDKConfig(
@@ -85,11 +117,11 @@ class DominoCDKConfig:
                 tags=c.pop("tags", {}),
                 create_iam_roles_for_service_accounts=c.pop("create_iam_roles_for_service_accounts", False),
                 vpc=VPC.from_0_0_1(c.pop("vpc")),
-                efs=EFS.from_0_0_0(c.pop("efs")),
-                route53=Route53.from_0_0_0(c.pop("route53")),
+                efs=efs,
+                route53=route53,
                 eks=EKS.from_0_0_1(c.pop("eks")),
-                s3=S3.from_0_0_0(c.pop("s3")),
-                install=Install.from_0_0_1(c.pop("install")),
+                s3=s3,
+                install=install,
             ),
             c,
         )

--- a/cdk/domino_cdk/config/base.py
+++ b/cdk/domino_cdk/config/base.py
@@ -54,21 +54,21 @@ class DominoCDKConfig:
 
     @staticmethod
     def from_0_0_0(c: dict):
-        s3 = None
-        if cfg := c.pop("s3", None):
-            s3 = S3.from_0_0_0(cfg)
+        s3 = c.pop("s3", None)
+        if s3 is not None:
+            s3 = S3.from_0_0_0(s3)
 
-        route53 = None
-        if cfg := c.pop("route53", None):
-            route53 = Route53.from_0_0_0(cfg)
+        route53 = c.pop("route53", None)
+        if route53 is not None:
+            route53 = Route53.from_0_0_0(route53)
 
-        efs = None
-        if cfg := c.pop("efs", None):
-            route53 = EFS.from_0_0_0(cfg)
+        efs = c.pop("efs", None)
+        if efs is not None:
+            efs = EFS.from_0_0_0(efs)
 
-        install = None
-        if cfg := c.pop("install", None):
-            install = Install.from_0_0_0(cfg)
+        install = c.pop("install", None)
+        if install is not None:
+            install = Install.from_0_0_0(install)
 
         return from_loader(
             "config",
@@ -91,21 +91,21 @@ class DominoCDKConfig:
 
     @staticmethod
     def from_0_0_1(c: dict):
-        s3 = None
-        if cfg := c.pop("s3", None):
-            s3 = S3.from_0_0_0(cfg)
+        s3 = c.pop("s3", None)
+        if s3 is not None:
+            s3 = S3.from_0_0_0(s3)
 
-        route53 = None
-        if cfg := c.pop("route53", None):
-            route53 = Route53.from_0_0_0(cfg)
+        route53 = c.pop("route53", None)
+        if route53 is not None:
+            route53 = Route53.from_0_0_0(route53)
 
-        efs = None
-        if cfg := c.pop("efs", None):
-            route53 = EFS.from_0_0_0(cfg)
+        efs = c.pop("efs", None)
+        if efs is not None:
+            efs = EFS.from_0_0_0(efs)
 
-        install = None
-        if cfg := c.pop("install", None):
-            install = Install.from_0_0_1(cfg)
+        install = c.pop("install", None)
+        if install is not None:
+            install = Install.from_0_0_1(install)
 
         return from_loader(
             "config",

--- a/cdk/domino_cdk/config/base.py
+++ b/cdk/domino_cdk/config/base.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, fields, is_dataclass
 from textwrap import dedent
-from typing import Dict
+from typing import Dict, Optional
 
 import boto3
 from field_properties import field_property, unwrap_property
@@ -34,12 +34,12 @@ class DominoCDKConfig:
     create_iam_roles_for_service_accounts: bool = False
 
     vpc: VPC = None
-    efs: EFS = None
+    efs: Optional[EFS] = None
     route53: Route53 = None
     eks: EKS = None
-    s3: S3 = None
-
-    install: Install = None
+    s3: Optional[S3] = None
+    
+    install: Optional[Install] = None
 
     @field_property(tags)
     def get_tags(self) -> Dict[str, str]:

--- a/cdk/domino_cdk/config/base.py
+++ b/cdk/domino_cdk/config/base.py
@@ -38,7 +38,7 @@ class DominoCDKConfig:
     route53: Route53 = None
     eks: EKS = None
     s3: Optional[S3] = None
-    
+
     install: Optional[Install] = None
 
     @field_property(tags)

--- a/cdk/domino_cdk/config/efs.py
+++ b/cdk/domino_cdk/config/efs.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 from domino_cdk.config.util import from_loader
 
@@ -26,23 +27,30 @@ class EFS:
         delete_after: int
         removal_policy: str
 
+    enabled: bool
     backup: Backup
     removal_policy_destroy: bool
 
     @staticmethod
-    def from_0_0_0(c: dict):
-        backup = c.pop("backup")
-        return from_loader(
-            "config.efs",
-            EFS(
-                backup=EFS.Backup(
-                    enable=backup.pop("enable"),
-                    schedule=backup.pop("schedule"),
-                    move_to_cold_storage_after=backup.pop("move_to_cold_storage_after", None),
-                    delete_after=backup.pop("delete_after", None),
-                    removal_policy=backup.pop("removal_policy", None),
+    def from_0_0_0(c: dict) -> Optional['EFS']:
+        enabled = c.get("enabled", True)
+        if "enabled" in c: del c["enabled"]
+
+        if enabled:
+            backup = c.pop("backup")
+            return from_loader(
+                "config.efs",
+                EFS(
+                    backup=EFS.Backup(
+                        enable=backup.pop("enable"),
+                        schedule=backup.pop("schedule"),
+                        move_to_cold_storage_after=backup.pop("move_to_cold_storage_after", None),
+                        delete_after=backup.pop("delete_after", None),
+                        removal_policy=backup.pop("removal_policy", None),
+                    ),
+                    removal_policy_destroy=c.pop("removal_policy_destroy", None),
                 ),
-                removal_policy_destroy=c.pop("removal_policy_destroy", None),
-            ),
-            c,
-        )
+                c,
+            )
+        else:
+            return None

--- a/cdk/domino_cdk/config/efs.py
+++ b/cdk/domino_cdk/config/efs.py
@@ -29,17 +29,9 @@ class EFS:
 
     backup: Backup
     removal_policy_destroy: bool
-    enabled: bool = True
 
     @staticmethod
     def from_0_0_0(c: dict) -> Optional['EFS']:
-        enabled = c.get("enabled", True)
-        if "enabled" in c:
-            del c["enabled"]
-
-        if not enabled:
-            return None
-
         backup = c.pop("backup")
         return from_loader(
             "config.efs",

--- a/cdk/domino_cdk/config/efs.py
+++ b/cdk/domino_cdk/config/efs.py
@@ -27,14 +27,15 @@ class EFS:
         delete_after: int
         removal_policy: str
 
-    enabled: bool
     backup: Backup
     removal_policy_destroy: bool
+    enabled: bool = True
 
     @staticmethod
     def from_0_0_0(c: dict) -> Optional['EFS']:
         enabled = c.get("enabled", True)
-        if "enabled" in c: del c["enabled"]
+        if "enabled" in c:
+            del c["enabled"]
 
         if enabled:
             backup = c.pop("backup")

--- a/cdk/domino_cdk/config/efs.py
+++ b/cdk/domino_cdk/config/efs.py
@@ -37,21 +37,21 @@ class EFS:
         if "enabled" in c:
             del c["enabled"]
 
-        if enabled:
-            backup = c.pop("backup")
-            return from_loader(
-                "config.efs",
-                EFS(
-                    backup=EFS.Backup(
-                        enable=backup.pop("enable"),
-                        schedule=backup.pop("schedule"),
-                        move_to_cold_storage_after=backup.pop("move_to_cold_storage_after", None),
-                        delete_after=backup.pop("delete_after", None),
-                        removal_policy=backup.pop("removal_policy", None),
-                    ),
-                    removal_policy_destroy=c.pop("removal_policy_destroy", None),
-                ),
-                c,
-            )
-        else:
+        if not enabled:
             return None
+
+        backup = c.pop("backup")
+        return from_loader(
+            "config.efs",
+            EFS(
+                backup=EFS.Backup(
+                    enable=backup.pop("enable"),
+                    schedule=backup.pop("schedule"),
+                    move_to_cold_storage_after=backup.pop("move_to_cold_storage_after", None),
+                    delete_after=backup.pop("delete_after", None),
+                    removal_policy=backup.pop("removal_policy", None),
+                ),
+                removal_policy_destroy=c.pop("removal_policy_destroy", None),
+            ),
+            c,
+        )

--- a/cdk/domino_cdk/config/install.py
+++ b/cdk/domino_cdk/config/install.py
@@ -27,12 +27,13 @@ class Install:
     registry_password: str
     overrides: dict
     istio_compatible: bool
-    enabled: bool
+    enabled: bool = True
 
     @staticmethod
     def from_0_0_0(c: dict) -> Optional['Install']:
         enabled = c.get("enabled", True)
-        if 'enabled' in c: del c['enabled']
+        if 'enabled' in c:
+            del c['enabled']
 
         if enabled:
             return from_loader(
@@ -54,7 +55,8 @@ class Install:
     @staticmethod
     def from_0_0_1(c: dict) -> Optional['Install']:
         enabled = c.get("enabled", True)
-        if 'enabled' in c: del c['enabled']
+        if 'enabled' in c:
+            del c['enabled']
 
         if enabled:
             return from_loader(

--- a/cdk/domino_cdk/config/install.py
+++ b/cdk/domino_cdk/config/install.py
@@ -27,17 +27,9 @@ class Install:
     registry_password: str
     overrides: dict
     istio_compatible: bool
-    enabled: bool = True
 
     @staticmethod
     def from_0_0_0(c: dict) -> Optional['Install']:
-        enabled = c.get("enabled", True)
-        if 'enabled' in c:
-            del c['enabled']
-
-        if not enabled:
-            return None
-
         return from_loader(
             "config.install",
             Install(
@@ -54,12 +46,6 @@ class Install:
 
     @staticmethod
     def from_0_0_1(c: dict) -> Optional['Install']:
-        enabled = c.get("enabled", True)
-        if 'enabled' in c:
-            del c['enabled']
-        if not enabled:
-            return None
-
         return from_loader(
             "config.install",
             Install(

--- a/cdk/domino_cdk/config/install.py
+++ b/cdk/domino_cdk/config/install.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 from domino_cdk.config.util import from_loader
 
@@ -27,35 +27,48 @@ class Install:
     registry_password: str
     overrides: dict
     istio_compatible: bool
+    enabled: bool
 
     @staticmethod
-    def from_0_0_0(c: dict):
-        return from_loader(
-            "config.install",
-            Install(
-                access_list=["0.0.0.0/0"],
-                acm_cert_arn=None,
-                hostname=None,
-                registry_username=None,
-                registry_password=None,
-                istio_compatible=False,
-                overrides=c,
-            ),
-            c,
-        )
+    def from_0_0_0(c: dict) -> Optional['Install']:
+        enabled = c.get("enabled", True)
+        if 'enabled' in c: del c['enabled']
+
+        if enabled:
+            return from_loader(
+                "config.install",
+                Install(
+                    access_list=["0.0.0.0/0"],
+                    acm_cert_arn=None,
+                    hostname=None,
+                    registry_username=None,
+                    registry_password=None,
+                    istio_compatible=False,
+                    overrides=c,
+                ),
+                c,
+            )
+        else:
+            return None
 
     @staticmethod
-    def from_0_0_1(c: dict):
-        return from_loader(
-            "config.install",
-            Install(
-                access_list=c.pop("access_list"),
-                acm_cert_arn=c.pop("acm_cert_arn"),
-                hostname=c.pop("hostname"),
-                registry_username=c.pop("registry_username"),
-                registry_password=c.pop("registry_password"),
-                overrides=c.pop("overrides"),
-                istio_compatible=c.pop("istio_compatible", False),
-            ),
-            c,
-        )
+    def from_0_0_1(c: dict) -> Optional['Install']:
+        enabled = c.get("enabled", True)
+        if 'enabled' in c: del c['enabled']
+
+        if enabled:
+            return from_loader(
+                "config.install",
+                Install(
+                    access_list=c.pop("access_list"),
+                    acm_cert_arn=c.pop("acm_cert_arn"),
+                    hostname=c.pop("hostname"),
+                    registry_username=c.pop("registry_username"),
+                    registry_password=c.pop("registry_password"),
+                    overrides=c.pop("overrides"),
+                    istio_compatible=c.pop("istio_compatible", False),
+                ),
+                c,
+            )
+        else:
+            return None

--- a/cdk/domino_cdk/config/install.py
+++ b/cdk/domino_cdk/config/install.py
@@ -35,42 +35,41 @@ class Install:
         if 'enabled' in c:
             del c['enabled']
 
-        if enabled:
-            return from_loader(
-                "config.install",
-                Install(
-                    access_list=["0.0.0.0/0"],
-                    acm_cert_arn=None,
-                    hostname=None,
-                    registry_username=None,
-                    registry_password=None,
-                    istio_compatible=False,
-                    overrides=c,
-                ),
-                c,
-            )
-        else:
+        if not enabled:
             return None
+
+        return from_loader(
+            "config.install",
+            Install(
+                access_list=["0.0.0.0/0"],
+                acm_cert_arn=None,
+                hostname=None,
+                registry_username=None,
+                registry_password=None,
+                istio_compatible=False,
+                overrides=c,
+            ),
+            c,
+        )
 
     @staticmethod
     def from_0_0_1(c: dict) -> Optional['Install']:
         enabled = c.get("enabled", True)
         if 'enabled' in c:
             del c['enabled']
-
-        if enabled:
-            return from_loader(
-                "config.install",
-                Install(
-                    access_list=c.pop("access_list"),
-                    acm_cert_arn=c.pop("acm_cert_arn"),
-                    hostname=c.pop("hostname"),
-                    registry_username=c.pop("registry_username"),
-                    registry_password=c.pop("registry_password"),
-                    overrides=c.pop("overrides"),
-                    istio_compatible=c.pop("istio_compatible", False),
-                ),
-                c,
-            )
-        else:
+        if not enabled:
             return None
+
+        return from_loader(
+            "config.install",
+            Install(
+                access_list=c.pop("access_list"),
+                acm_cert_arn=c.pop("acm_cert_arn"),
+                hostname=c.pop("hostname"),
+                registry_username=c.pop("registry_username"),
+                registry_password=c.pop("registry_password"),
+                overrides=c.pop("overrides"),
+                istio_compatible=c.pop("istio_compatible", False),
+            ),
+            c,
+        )

--- a/cdk/domino_cdk/config/route53.py
+++ b/cdk/domino_cdk/config/route53.py
@@ -12,15 +12,8 @@ class Route53:
     """
 
     zone_ids: List[str]
-    enabled: bool = True
 
     @staticmethod
     def from_0_0_0(c: dict) -> Optional['Route53']:
-        enabled = c.get("enabled", True)
-        if "enabled" in c:
-            del c["enabled"]
-
-        if not enabled:
-            return None
 
         return from_loader("config.route53", Route53(zone_ids=c.pop("zone_ids", None)), c)

--- a/cdk/domino_cdk/config/route53.py
+++ b/cdk/domino_cdk/config/route53.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 from domino_cdk.config.util import from_loader
 
@@ -14,5 +14,11 @@ class Route53:
     zone_ids: List[str]
 
     @staticmethod
-    def from_0_0_0(c: dict):
-        return from_loader("config.route53", Route53(zone_ids=c.pop("zone_ids", None)), c)
+    def from_0_0_0(c: dict) -> Optional['Reoute53']:
+        enabled = c.get("enabled", True)
+        if "enabled" in c: del c["enabled"]
+
+        if enabled:
+            return from_loader("config.route53", Route53(zone_ids=c.pop("zone_ids", None)), c)
+        else:
+            return None

--- a/cdk/domino_cdk/config/route53.py
+++ b/cdk/domino_cdk/config/route53.py
@@ -20,7 +20,7 @@ class Route53:
         if "enabled" in c:
             del c["enabled"]
 
-        if enabled:
-            return from_loader("config.route53", Route53(zone_ids=c.pop("zone_ids", None)), c)
-        else:
+        if not enabled:
             return None
+
+        return from_loader("config.route53", Route53(zone_ids=c.pop("zone_ids", None)), c)

--- a/cdk/domino_cdk/config/route53.py
+++ b/cdk/domino_cdk/config/route53.py
@@ -12,11 +12,13 @@ class Route53:
     """
 
     zone_ids: List[str]
+    enabled: bool = True
 
     @staticmethod
-    def from_0_0_0(c: dict) -> Optional['Reoute53']:
+    def from_0_0_0(c: dict) -> Optional['Route53']:
         enabled = c.get("enabled", True)
-        if "enabled" in c: del c["enabled"]
+        if "enabled" in c:
+            del c["enabled"]
 
         if enabled:
             return from_loader("config.route53", Route53(zone_ids=c.pop("zone_ids", None)), c)

--- a/cdk/domino_cdk/config/s3.py
+++ b/cdk/domino_cdk/config/s3.py
@@ -84,11 +84,11 @@ class S3:
         if 'enabled' in c:
             del c['enabled']
 
-        if enabled:
-            return from_loader(
-                "config.s3",
-                S3(buckets=S3.BucketList.load(c.pop("buckets")), enabled=True),
-                c,
-            )
-        else:
+        if not enabled:
             return None
+
+        return from_loader(
+            "config.s3",
+            S3(buckets=S3.BucketList.load(c.pop("buckets")), enabled=True),
+            c,
+        )

--- a/cdk/domino_cdk/config/s3.py
+++ b/cdk/domino_cdk/config/s3.py
@@ -75,12 +75,23 @@ class S3:
             if errors and not getenv("SKIP_UNDEFINED_BUCKETS"):
                 raise ValueError(errors)
 
-    buckets: BucketList
+    enabled: bool
+    buckets: Optional[BucketList]
 
     @staticmethod
-    def from_0_0_0(c: dict):
-        return from_loader(
-            "config.s3",
-            S3(buckets=S3.BucketList.load(c.pop("buckets"))),
-            c,
-        )
+    def from_0_0_0(c: dict) -> Optional['S3']:
+        enabled = c.get("enabled", True)
+        if 'enabled' in c: del c['enabled']
+
+        if enabled:
+            return from_loader(
+                "config.s3",
+                S3(
+                    buckets=S3.BucketList.load(c.pop("buckets")),
+                    enabled = True
+                ),
+                c,
+            )
+        else:
+            return None
+

--- a/cdk/domino_cdk/config/s3.py
+++ b/cdk/domino_cdk/config/s3.py
@@ -75,23 +75,20 @@ class S3:
             if errors and not getenv("SKIP_UNDEFINED_BUCKETS"):
                 raise ValueError(errors)
 
-    enabled: bool
     buckets: Optional[BucketList]
+    enabled: bool = True
 
     @staticmethod
     def from_0_0_0(c: dict) -> Optional['S3']:
         enabled = c.get("enabled", True)
-        if 'enabled' in c: del c['enabled']
+        if 'enabled' in c:
+            del c['enabled']
 
         if enabled:
             return from_loader(
                 "config.s3",
-                S3(
-                    buckets=S3.BucketList.load(c.pop("buckets")),
-                    enabled = True
-                ),
+                S3(buckets=S3.BucketList.load(c.pop("buckets")), enabled=True),
                 c,
             )
         else:
             return None
-

--- a/cdk/domino_cdk/config/s3.py
+++ b/cdk/domino_cdk/config/s3.py
@@ -76,17 +76,9 @@ class S3:
                 raise ValueError(errors)
 
     buckets: BucketList
-    enabled: bool = True
 
     @staticmethod
     def from_0_0_0(c: dict) -> Optional['S3']:
-        enabled = c.get("enabled", True)
-        if 'enabled' in c:
-            del c['enabled']
-
-        if not enabled:
-            return None
-
         return from_loader(
             "config.s3",
             S3(buckets=S3.BucketList.load(c.pop("buckets"))),

--- a/cdk/domino_cdk/config/s3.py
+++ b/cdk/domino_cdk/config/s3.py
@@ -75,7 +75,7 @@ class S3:
             if errors and not getenv("SKIP_UNDEFINED_BUCKETS"):
                 raise ValueError(errors)
 
-    buckets: Optional[BucketList]
+    buckets: BucketList
     enabled: bool = True
 
     @staticmethod
@@ -89,6 +89,6 @@ class S3:
 
         return from_loader(
             "config.s3",
-            S3(buckets=S3.BucketList.load(c.pop("buckets")), enabled=True),
+            S3(buckets=S3.BucketList.load(c.pop("buckets"))),
             c,
         )

--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -1,5 +1,7 @@
-from aws_cdk import core as cdk
+from typing import Optional
+
 import aws_cdk.aws_s3 as s3
+from aws_cdk import core as cdk
 
 from domino_cdk.agent import generate_install_config
 from domino_cdk.aws_configurator import DominoAwsConfigurator
@@ -16,7 +18,6 @@ from domino_cdk.provisioners.eks.eks_iam_roles_for_k8s import (
 from domino_cdk.provisioners.lambda_utils import create_lambda
 from domino_cdk.util import DominoCdkUtil
 
-from typing import Optional
 
 class DominoStack(cdk.Stack):
     efs_stack: Optional[DominoEfsProvisioner] = None
@@ -58,7 +59,9 @@ class DominoStack(cdk.Stack):
             self.cfg.route53.zone_ids,
             nest,
             # Do not pass list of buckets to Eks provisioner if we are not using S3 access per node
-            self.s3_stack.buckets if self.s3_stack is not None and cfg.create_iam_roles_for_service_accounts is False else [],
+            self.s3_stack.buckets
+            if self.s3_stack is not None and cfg.create_iam_roles_for_service_accounts is False
+            else [],
         )
 
         if cfg.create_iam_roles_for_service_accounts:
@@ -147,5 +150,5 @@ class DominoStack(cdk.Stack):
             merged_cfg = DominoCdkUtil.deep_merge(agent_cfg, self.cfg.install.overrides)
 
             cdk.CfnOutput(self, "agent_config", value=DominoCdkUtil.ruamel_dump(merged_cfg))
-            
+
         cdk.CfnOutput(self, "cdk_config", value=DominoCdkUtil.ruamel_dump(self.cfg.render(True)))

--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -1,4 +1,5 @@
 from aws_cdk import core as cdk
+import aws_cdk.aws_s3 as s3
 
 from domino_cdk.agent import generate_install_config
 from domino_cdk.aws_configurator import DominoAwsConfigurator
@@ -15,8 +16,13 @@ from domino_cdk.provisioners.eks.eks_iam_roles_for_k8s import (
 from domino_cdk.provisioners.lambda_utils import create_lambda
 from domino_cdk.util import DominoCdkUtil
 
+from typing import Optional
 
 class DominoStack(cdk.Stack):
+    efs_stack: Optional[DominoEfsProvisioner] = None
+    s3_stack: Optional[DominoS3Provisioner] = None
+    monitoring_bucket: Optional[s3.Bucket] = None
+
     def __init__(
         self, scope: cdk.Construct, construct_id: str, cfg: DominoCDKConfig, nest: bool = True, **kwargs
     ) -> None:
@@ -33,10 +39,12 @@ class DominoStack(cdk.Stack):
         for k, v in self.cfg.tags.items():
             cdk.Tags.of(self).add(str(k), str(v))
 
-        self.s3_stack = DominoS3Provisioner(self, "S3Stack", self.name, self.cfg.s3, nest)
+        if self.cfg.s3 is not None:
+            self.s3_stack = DominoS3Provisioner(self, "S3Stack", self.name, self.cfg.s3, nest)
+            self.monitoring_bucket = self.s3_stack.monitoring_bucket
 
         self.vpc_stack = DominoVpcProvisioner(
-            self, "VpcStack", self.name, self.cfg.vpc, nest, monitoring_bucket=self.s3_stack.monitoring_bucket
+            self, "VpcStack", self.name, self.cfg.vpc, nest, monitoring_bucket=self.monitoring_bucket
         )
 
         self.eks_stack = DominoEksProvisioner(
@@ -50,21 +58,22 @@ class DominoStack(cdk.Stack):
             self.cfg.route53.zone_ids,
             nest,
             # Do not pass list of buckets to Eks provisioner if we are not using S3 access per node
-            self.s3_stack.buckets if cfg.create_iam_roles_for_service_accounts is False else [],
+            self.s3_stack.buckets if self.s3_stack is not None and cfg.create_iam_roles_for_service_accounts is False else [],
         )
 
         if cfg.create_iam_roles_for_service_accounts:
             DominoEksK8sIamRolesProvisioner(self).provision(self.name, self.eks_stack.cluster, self.s3_stack.buckets)
 
-        self.efs_stack = DominoEfsProvisioner(
-            self,
-            "EfsStack",
-            self.name,
-            self.cfg.efs,
-            self.vpc_stack.vpc,
-            self.eks_stack.cluster.cluster_security_group,
-            nest,
-        )
+        if self.cfg.efs is not None:
+            self.efs_stack = DominoEfsProvisioner(
+                self,
+                "EfsStack",
+                self.name,
+                self.cfg.efs,
+                self.vpc_stack.vpc,
+                self.eks_stack.cluster.cluster_security_group,
+                nest,
+            )
 
         create_lambda(
             scope=self,
@@ -98,17 +107,17 @@ class DominoStack(cdk.Stack):
         self.generate_outputs()
 
     def generate_outputs(self):
-        efs_fs_ap_id = f"{self.efs_stack.efs.file_system_id}::{self.efs_stack.efs_access_point.access_point_id}"
-        r53_zone_ids = self.cfg.route53.zone_ids
-        r53_owner_id = f"{self.name}CDK"
+        if self.efs_stack is not None:
+            efs_fs_ap_id = f"{self.efs_stack.efs.file_system_id}::{self.efs_stack.efs_access_point.access_point_id}"
+            cdk.CfnOutput(
+                self,
+                "efs-output",
+                value=efs_fs_ap_id,
+            )
 
-        cdk.CfnOutput(
-            self,
-            "efs-output",
-            value=efs_fs_ap_id,
-        )
-
-        if r53_zone_ids:
+        if self.cfg.route53 is not None:
+            r53_zone_ids = self.cfg.route53.zone_ids
+            r53_owner_id = f"{self.name}CDK"
             cdk.CfnOutput(
                 self,
                 "route53-zone-id-output",
@@ -120,21 +129,23 @@ class DominoStack(cdk.Stack):
                 value=r53_owner_id,
             )
 
-        agent_cfg = generate_install_config(
-            name=self.name,
-            install=self.cfg.install,
-            aws_region=self.cfg.aws_region,
-            eks_cluster_name=self.eks_stack.cluster.cluster_name,
-            pod_cidr=self.vpc_stack.vpc.vpc_cidr_block,
-            global_node_selectors=self.cfg.eks.global_node_labels,
-            buckets=self.s3_stack.buckets,
-            monitoring_bucket=self.s3_stack.monitoring_bucket,
-            efs_fs_ap_id=efs_fs_ap_id,
-            r53_zone_ids=r53_zone_ids,
-            r53_owner_id=r53_owner_id,
-        )
+        if self.cfg.install is not None:
+            agent_cfg = generate_install_config(
+                name=self.name,
+                install=self.cfg.install,
+                aws_region=self.cfg.aws_region,
+                eks_cluster_name=self.eks_stack.cluster.cluster_name,
+                pod_cidr=self.vpc_stack.vpc.vpc_cidr_block,
+                global_node_selectors=self.cfg.eks.global_node_labels,
+                buckets=self.s3_stack.buckets,
+                monitoring_bucket=self.s3_stack.monitoring_bucket,
+                efs_fs_ap_id=efs_fs_ap_id,
+                r53_zone_ids=r53_zone_ids,
+                r53_owner_id=r53_owner_id,
+            )
 
-        merged_cfg = DominoCdkUtil.deep_merge(agent_cfg, self.cfg.install.overrides)
+            merged_cfg = DominoCdkUtil.deep_merge(agent_cfg, self.cfg.install.overrides)
 
-        cdk.CfnOutput(self, "agent_config", value=DominoCdkUtil.ruamel_dump(merged_cfg))
+            cdk.CfnOutput(self, "agent_config", value=DominoCdkUtil.ruamel_dump(merged_cfg))
+            
         cdk.CfnOutput(self, "cdk_config", value=DominoCdkUtil.ruamel_dump(self.cfg.render(True)))

--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -56,7 +56,7 @@ class DominoStack(cdk.Stack):
             self.vpc_stack.vpc,
             self.vpc_stack.private_subnet_name,
             self.vpc_stack.bastion_sg,
-            self.cfg.route53.zone_ids,
+            self.cfg.route53.zone_ids if self.cfg.route53 is not None else [],
             nest,
             # Do not pass list of buckets to Eks provisioner if we are not using S3 access per node
             self.s3_stack.buckets

--- a/cdk/tests/unit/config/test_config.py
+++ b/cdk/tests/unit/config/test_config.py
@@ -27,6 +27,8 @@ class TestConfig(unittest.TestCase):
         with patch("domino_cdk.config.util.log.warning") as warn:
             template = deepcopy(legacy_template)
             c = config_loader(template)
+            print(c)
+            print(legacy_config)
             self.assertEqual(c, legacy_config)
             warn.assert_called_with(
                 "Warning: Unused/unsupported config entries in config.vpc: {'bastion': {'enabled': False, 'instance_type': None, 'ingress_ports': None}}"

--- a/cdk/tests/unit/config/test_config.py
+++ b/cdk/tests/unit/config/test_config.py
@@ -27,8 +27,6 @@ class TestConfig(unittest.TestCase):
         with patch("domino_cdk.config.util.log.warning") as warn:
             template = deepcopy(legacy_template)
             c = config_loader(template)
-            print(c)
-            print(legacy_config)
             self.assertEqual(c, legacy_config)
             warn.assert_called_with(
                 "Warning: Unused/unsupported config entries in config.vpc: {'bastion': {'enabled': False, 'instance_type': None, 'ingress_ports': None}}"


### PR DESCRIPTION
Introduce optional `enabled` field (default `true`) to configurations for following resources:

* S3 buckets
* EFS
* Route53
* Installer configuration

This would allow the deployer to simply set `enabled: false` for each of these resource configurations to deploy a data plane VPC / EKS cluster with identical configuration as our existing dev/prod CDK flavors. 