### PR TITLE
Enable customers to bring their own vpc's

### DIFF
--- a/cdk/domino_cdk/provisioners/vpc.py
+++ b/cdk/domino_cdk/provisioners/vpc.py
@@ -35,7 +35,7 @@ class DominoVpcProvisioner:
         self.public_subnet_name = f"{stack_name}-Public"
         self.private_subnet_name = f"{stack_name}-Private"
         if not vpc.create:
-            self.vpc = ec2.Vpc.from_lookup(self.scope, vpc.id)
+            self.vpc = ec2.Vpc.from_lookup(self.scope, vpc.id, vpc_id=vpc.id)
             return
 
         nat_provider = ec2.NatProvider.gateway()


### PR DESCRIPTION
Per documentation https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_ec2/VpcLookupOptions.html this is required to look up a vpc. 

Addresses PLAT-4992