### PR TITLE
Update iam.py

### DIFF
--- a/cdk/domino_cdk/config/iam.py
+++ b/cdk/domino_cdk/config/iam.py
@@ -134,6 +134,9 @@ def generate_iam(stack_name: str, aws_account_id: str, region: str, manual: bool
             "lambda:InvokeFunction",
             "lambda:PublishLayerVersion",
             "lambda:UpdateFunctionConfiguration",
+            "lambda:ListTags",
+            "lambda:TagResource",
+            "lambda:UntagResource",
         ],
         **from_cf_condition,
         "Resource": [


### PR DESCRIPTION
V54 of the deployer requires the iam user to tag the lambda functions which is failing.