### PR TITLE
remove prune setting for eks cluster

### DIFF
--- a/cdk/domino_cdk/provisioners/eks/eks_cluster.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_cluster.py
@@ -77,6 +77,7 @@ class DominoEksClusterProvisioner:
             default_capacity=0,
             security_group=eks_sg,
             secrets_encryption_key=key,
+            prune=False,  # https://github.com/aws/aws-cdk/issues/19843
         )
 
         # To make sure log cleanup is called after cluster cleanup: cluster depends on custom so custom is guaranteed


### PR DESCRIPTION
AWS-CDK's lambda for generic kubernetes manifests doesn't support 1.22 officially so `prune` bails on the missing API versions (like ingress). This occurs during updates to an existing cluster. If/when we update Calico, this may affect how the upgrades from [one version to another works](https://github.com/dominodatalab/cdk-cf-eks/blob/master/cdk/domino_cdk/aws_configurator.py).

See https://github.com/aws/aws-cdk/issues/19843 for more context. https://github.com/aws/aws-cdk/issues/15736#issuecomment-1212926265 does indicate a workaround, but it doesn't seem very palatable.

deployer_image: quay.io/domino/deployer:steved-destroy-deploy.latest