### PR TITLE
DOM-32528: Update EKS nginx ELB SSL security policy

### DIFF
--- a/cdk/domino_cdk/agent.py
+++ b/cdk/domino_cdk/agent.py
@@ -106,6 +106,7 @@ def generate_install_config(
                 "enabled": True,
                 "type": "LoadBalancer",
                 "annotations": {
+                    "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
                     "service.beta.kubernetes.io/aws-load-balancer-ssl-cert": install.acm_cert_arn or "__FILL__",
                     "service.beta.kubernetes.io/aws-load-balancer-internal": False,
                     "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "tcp",

--- a/cdk/tests/unit/test_agent.py
+++ b/cdk/tests/unit/test_agent.py
@@ -55,6 +55,7 @@ class TestAgent(TestCase):
                         "type": "LoadBalancer",
                         "targetPorts": {"http": "http", "https": "https"},
                         "annotations": {
+                            "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
                             "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "ssl",
                             "service.beta.kubernetes.io/aws-load-balancer-ssl-cert": "acm:cert:arn",
                             "service.beta.kubernetes.io/aws-load-balancer-internal": False,
@@ -107,6 +108,7 @@ class TestAgent(TestCase):
                         "type": "LoadBalancer",
                         "targetPorts": {"http": "http", "https": "http"},
                         "annotations": {
+                            "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
                             "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "tcp",
                             "service.beta.kubernetes.io/aws-load-balancer-ssl-cert": "acm:cert:arn",
                             "service.beta.kubernetes.io/aws-load-balancer-internal": False,

--- a/cdk/tests/unit/test_agent.py
+++ b/cdk/tests/unit/test_agent.py
@@ -20,7 +20,7 @@ class TestAgent(TestCase):
             "registry": Bucket(self.stack, "s3-registry"),
         }
 
-    def test_generate_intsall_config_istio(self):
+    def test_generate_install_config_istio(self):
         config = generate_install_config(
             "test",
             Install(
@@ -73,7 +73,7 @@ class TestAgent(TestCase):
             },
         )
 
-    def test_generate_intsall_config(self):
+    def test_generate_install_config(self):
         config = generate_install_config(
             "test",
             Install(


### PR DESCRIPTION
Update default Domino EKS deployment ELB cipher suite to TLS 1.2 only
before:
![image](https://user-images.githubusercontent.com/98769216/186700220-92156abf-fd33-4235-82aa-1d59fe5295f8.png)
after:
![image](https://user-images.githubusercontent.com/98769216/186700265-42a2198d-da44-4fd4-99a8-3f2d8f28204e.png)
