### PR TITLE
Dumb fix for diff false positives on calico

### DIFF
--- a/cdk/domino_cdk/aws_configurator.py
+++ b/cdk/domino_cdk/aws_configurator.py
@@ -1,6 +1,7 @@
 from io import StringIO
 from os.path import isfile
 from pathlib import Path
+from re import sub
 
 import aws_cdk.aws_eks as eks
 from aws_cdk import core as cdk
@@ -48,7 +49,8 @@ class DominoAwsConfigurator:
             if isfile(filename):
                 stream = Path(filename)
             else:
-                stream = StringIO(requests_get(url).text)
+                # Something downstream will make this substitution anyway, cause fake diffs
+                stream = StringIO(sub(r'[“”]', '?', requests_get(url).text))
 
             yaml = YAML(typ="safe")
             loaded_manifests = list(yaml.load_all(stream))


### PR DESCRIPTION
There are some obnoxious utf-8 quotes in the calico manifest for some reason, which get automatically converted to `?` by AWS at some point. Because of this, they _always_ present as a difference when doing `cdk diff`.

This change performs that same conversion, but within our cdk app. Because this is json, I do the same thing they do and convert it to `?` rather than `"`, as otherwise we're put in the position of iterating through every key and value individually to perform the substitutions to do it safely.