### PR TITLE
update lambda to use cfnresponse

### DIFF
--- a/cdk/domino_cdk/provisioners/lambda_files/backup_post_creation_tasks.py
+++ b/cdk/domino_cdk/provisioners/lambda_files/backup_post_creation_tasks.py
@@ -30,6 +30,4 @@ def on_delete(event):
     print(f'Delete backup points in backup vault {backup_vault_name}')
     response = client.list_recovery_points_by_backup_vault(BackupVaultName=backup_vault_name)
     for rp in response['RecoveryPoints']:
-        response = client.delete_recovery_point(
-            BackupVaultName=backup_vault_name, RecoveryPointArn=rp['RecoveryPointArn']
-        )
+        client.delete_recovery_point(BackupVaultName=backup_vault_name, RecoveryPointArn=rp['RecoveryPointArn'])

--- a/cdk/domino_cdk/provisioners/lambda_files/fix_missing_tags.py
+++ b/cdk/domino_cdk/provisioners/lambda_files/fix_missing_tags.py
@@ -41,8 +41,8 @@ def tag_ec2(tags, stack_name, vpc_id, resource_ids):
     security_groups = client.describe_security_groups(
         Filters=[*vpc_filter, {"Name": "group-name", "Values": ["default"]}]
     )
-    if sg := security_groups["SecurityGroups"]:
-        resource_ids.append(sg[0]["GroupId"])
+    if security_groups["SecurityGroups"]:
+        resource_ids.append(security_groups["SecurityGroups"][0]["GroupId"])
 
     network_acls = client.describe_network_acls(Filters=vpc_filter)
     resource_ids.extend([acl["NetworkAclId"] for acl in network_acls["NetworkAcls"]])


### PR DESCRIPTION
When building a custom response, we were returning the resource property data which could exceed the 4k response limit.