### PR TITLE
Upgrading CDK failed with ListResourceTags missing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   test-build-deploy:
     runs-on: ubuntu-latest
     env:
-      DEPLOYER_IMAGE: quay.io/domino/deployer:schema1_2.latest
+      DEPLOYER_IMAGE: quay.io/domino/deployer:develop.50b440689b18e42391e8d07b54a9ea3fa8a4ae61
     defaults:
       run:
         working-directory: ./cdk

--- a/cdk/domino_cdk/config/iam.py
+++ b/cdk/domino_cdk/config/iam.py
@@ -261,6 +261,7 @@ def generate_iam(stack_name: str, aws_account_id: str, region: str, manual: bool
             "kms:DescribeKey",
             "kms:EnableKeyRotation",
             "kms:GenerateDataKey",
+            "kms:ListResourceTags",
             "kms:PutKeyPolicy",
             "kms:RetireGrant",
             "kms:ScheduleKeyDeletion",


### PR DESCRIPTION
kms require ListResourceTags due for EKS Secrets Envelope