### PR TITLE
PLAT-6040: Use partition in all arns

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   test-build-deploy:
     runs-on: ubuntu-latest
     env:
-      DEPLOYER_IMAGE: quay.io/domino/deployer:develop.172eca181b23921105a40286e064c4e6cd6d8186
+      DEPLOYER_IMAGE: quay.io/domino/deployer:develop.fd54002c320071e9133074d545843c7aac8d3e44
     defaults:
       run:
         working-directory: ./cdk

--- a/cdk/domino_cdk/config/iam.py
+++ b/cdk/domino_cdk/config/iam.py
@@ -35,7 +35,7 @@ def generate_iam(stack_name: str, aws_account_id: str, region: str, manual: bool
             "cloudformation:GetTemplate",
         ],
         "Resource": [
-            # f"arn:aws:cloudformation:*:{aws_account_id}:stack/{stack_name}-eks-stack/*",
+            # f"arn:{partition}:cloudformation:*:{aws_account_id}:stack/{stack_name}-eks-stack/*",
             f"arn:{partition}:cloudformation:*:{aws_account_id}:stack/{stack_name}*",
         ],
     }


### PR DESCRIPTION
To support govcloud, the correct partition must be used when building ARNs.