### PR TITLE
PLAT-6183: Update gpu remediation

### DIFF
--- a/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_nodegroup.py
@@ -263,11 +263,7 @@ class DominoEksNodegroupProvisioner:
                     ec2.MultipartBody.from_user_data(
                         ec2.UserData.custom(
                             'EKS_CONTAINERD_CFG="/etc/eks/containerd/containerd-config.toml"\n'
-                            'if [ -z "$(egrep \'certs\.d\' $EKS_CONTAINERD_CFG)" ]; then\n'
-                            '    if [ -n "$(egrep \'plugins\.cri\.containerd\.runtimes\.nvidia\' $EKS_CONTAINERD_CFG)" ]; then\n'
-                            '        printf \'\n\n[plugins.cri.registry]\nconfig_path = "/etc/containerd/certs.d:/etc/docker/certs.d"\n\' >> $EKS_CONTAINERD_CFG\n'
-                            '    fi\n'
-                            'fi\n'
+                            "sed -i 's/plugins\.\"io.containerd.grpc.v1.cri\"\.registry/plugins.cri.registry/' $EKS_CONTAINERD_CFG\n"
                         )
                     )
                 )


### PR DESCRIPTION
They release the fixed GPU ami, however, it was not, in reality, fixed.

See: https://github.com/awslabs/amazon-eks-ami/issues/1154#issuecomment-1414711705

Because the incorrect version of the certs config triggers the safety valve of the old remediation, a new one is needed.