### PR TITLE
add warnings and exceptions for agent template functionality

### DIFF
--- a/cdk/domino_cdk/config/base.py
+++ b/cdk/domino_cdk/config/base.py
@@ -66,7 +66,10 @@ class DominoCDKConfig:
             efs = EFS.from_0_0_0(efs)
 
         # Install is no longer supported
-        c.pop("install", None)
+        if c.pop("install", None):
+            raise ValueError(
+                "\"install\" is no longer a supported configurable, please directly modify the install configuration post-provision"
+            )
 
         acm = c.pop("acm", None)
         if acm is not None:
@@ -106,7 +109,10 @@ class DominoCDKConfig:
             efs = EFS.from_0_0_0(efs)
 
         # Install is no longer supported
-        c.pop("install", None)
+        if c.pop("install", None):
+            raise ValueError(
+                "\"install\" is no longer a supported configurable, please directly modify the install configuration post-provision"
+            )
 
         acm = c.pop("acm", None)
         if acm is not None:

--- a/cdk/domino_cdk/domino_stack.py
+++ b/cdk/domino_cdk/domino_stack.py
@@ -146,4 +146,10 @@ class DominoStack(cdk.Stack):
                 value=r53_owner_id,
             )
 
+        cdk.CfnOutput(
+            self,
+            "agent_config",
+            value="\"agent_config\" is no longer supported, please manually create your install configuration based on the provisioning outputs",
+        )
+
         cdk.CfnOutput(self, "cdk_config", value=DominoCdkUtil.ruamel_dump(self.cfg.render(True)))


### PR DESCRIPTION
Follow-up from https://github.com/dominodatalab/cdk-cf-eks/pull/129, raise an error if `install` is used in schema conversion and add a warning in the outputs.