### PR TITLE
PLAT-7108: import EIP using eipalloc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,13 +73,20 @@ jobs:
         REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         ACM_CERT_ARN: ${{ secrets.DELTA_ACM_CERT_ARN }}
         BASE_DOMAIN: ${{ secrets.DELTA_BASE_DOMAIN }}
+        JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: 1
       run: |
         export NAME=cdk-${GITHUB_SHA:0:6}-$(date +%s)
         echo "NAME=$NAME" >> $GITHUB_ENV
         ./util.py generate_config_template --name $NAME --aws-region=$AWS_REGION --aws-account-id=$AWS_ACCOUNT_ID --dev --platform-nodegroups 2 --registry-username $REGISTRY_USERNAME --registry-password $REGISTRY_PASSWORD --hostname $NAME.$BASE_DOMAIN --acm-cert-arn $ACM_CERT_ARN --disable-flow-logs > config.yaml
         ./util.py load_config -f ./config.yaml
     - name: Test default config (single and nested stacks)
+      env:
+        JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: 1
       run: |
+        echo 'CDK acknowledge: AWS CDK v1 End-of-Support June 1, 2023'
+        cdk acknowledge 19836
+        echo 'CDK acknowledge: (eks) eks overly permissive trust policies'
+        cdk acknowledge 25674
         cdk synth --context singlestack=true -q
         cdk synth -q
     - name: Upload distribution artifacts
@@ -95,11 +102,18 @@ jobs:
         urlfile=$(python -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip()))' <<< "$filename")
         echo "Artifact url: https://domino-artifacts.s3.amazonaws.com/cdk/$($DATEDIR)/$urlfile"
         done
+    - name: Bootstrap CDK
+      env:
+        AWS_ACCOUNT_ID: ${{ secrets.DELTA_ACCOUNT_ID }}
+        AWS_REGION: ${{ env.AWS_REGION }}
+        JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: 1
+      run: cdk bootstrap "aws://$AWS_ACCOUNT_ID/$AWS_REGION"
     - name: Deploy CDK
       if: contains(github.event.pull_request.labels.*.name, 'deploy-test') || github.ref == 'refs/heads/master'
       env:
         REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
         REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: 1
       run: |
         docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD quay.io
         cdk deploy --require-approval never --outputs-file outputs.json
@@ -187,15 +201,17 @@ jobs:
         aws-region: ${{ env.AWS_REGION }}
     - name: Delete stack w/CDK
       if: always() && (contains(github.event.pull_request.labels.*.name, 'deploy-test') || github.ref == 'refs/heads/master')
+      env:
+        JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: 1
       working-directory: ./cdk
       run: |
         cdk destroy --force
-    - name: Destroy Infrastructure
+    - name: Destroy Infrastructure tf
       if: always() && (contains(github.event.pull_request.labels.*.name, 'deploy-test') || github.ref == 'refs/heads/master')
       working-directory: ./convert/terraform
       run: |
         terraform destroy -auto-approve
-    - name: Destroy Infrastructure
+    - name: Destroy Infrastructure cf
       if: always() && (contains(github.event.pull_request.labels.*.name, 'deploy-test') || github.ref == 'refs/heads/master')
       working-directory: ./convert/cloudformation-only
       run: |

--- a/cdk/domino_cdk/provisioners/efs.py
+++ b/cdk/domino_cdk/provisioners/efs.py
@@ -45,7 +45,7 @@ class DominoEfsProvisioner:
             security_group=security_group,
             performance_mode=efs.PerformanceMode.GENERAL_PURPOSE,
             throughput_mode=efs.ThroughputMode.BURSTING,
-            vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE),
+            vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_NAT),
         )
 
         self.efs_access_point = self.efs.add_access_point(
@@ -69,7 +69,7 @@ class DominoEfsProvisioner:
         vault = backup.BackupVault(
             self.scope,
             "efs_backup",
-            backup_vault_name=f'{stack_name}-efs',
+            backup_vault_name=f"{stack_name}-efs",
             removal_policy=cdk.RemovalPolicy[efs_backup.removal_policy or cdk.RemovalPolicy.RETAIN.value],
         )
 

--- a/cdk/domino_cdk/provisioners/eks/eks_cluster.py
+++ b/cdk/domino_cdk/provisioners/eks/eks_cluster.py
@@ -73,7 +73,7 @@ class DominoEksClusterProvisioner:
             cluster_name=stack_name,
             vpc=vpc,
             endpoint_access=eks.EndpointAccess.PRIVATE if private_api else None,
-            vpc_subnets=[ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE)],
+            vpc_subnets=[ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_NAT)],
             version=eks_version,
             default_capacity=0,
             security_group=eks_sg,

--- a/cdk/domino_cdk/provisioners/vpc.py
+++ b/cdk/domino_cdk/provisioners/vpc.py
@@ -51,7 +51,7 @@ class DominoVpcProvisioner:
                     cidr_mask=vpc.public_cidr_mask,  # can't use token ids
                 ),
                 ec2.SubnetConfiguration(
-                    subnet_type=ec2.SubnetType.PRIVATE,
+                    subnet_type=ec2.SubnetType.PRIVATE_WITH_NAT,
                     name=self.private_subnet_name,
                     cidr_mask=vpc.private_cidr_mask,  # can't use token ids
                 ),
@@ -157,7 +157,7 @@ class DominoVpcProvisioner:
                     vpc=self.vpc,
                     security_groups=[endpoint_sg],
                     service=ec2.InterfaceVpcEndpointAwsService(endpoint, port=443),
-                    subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE),
+                    subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_NAT),
                 )
 
         # TODO until https://github.com/aws/aws-cdk/issues/14194

--- a/convert/lib/convert.py
+++ b/convert/lib/convert.py
@@ -605,10 +605,13 @@ class app:
             print(f"Deleting Stack: {stack_name} Status: {stack_status}")
             self.cf.delete_stack(StackName=stack_name, RoleARN=role_arn)
 
-        while (
-            stack_status := self.cf.describe_stacks(StackName=stack_name)["Stacks"][0]["StackStatus"]
-        ) != "DELETE_FAILED":
-            print(f"Waiting for stack{stack_name} to be in `DELETE_FAILED`...Currently: {stack_status}")
+        while (stack_status := self.cf.describe_stacks(StackName=stack_name)["Stacks"][0]["StackStatus"]) not in [
+            "DELETE_FAILED",
+            "DELETE_COMPLETED",
+        ]:
+            print(
+                f"Waiting for stack{stack_name} to be in `DELETE_FAILED` or `DELETE_COMPLETED`...Currently: {stack_status}"
+            )
             sleep(5)
 
         nested_stacks = self._get_nested_stacks(stack_name)

--- a/convert/lib/nuke.py
+++ b/convert/lib/nuke.py
@@ -104,7 +104,7 @@ class nuke:
                     tries=60,
                 )
                 def delete_asg(group: str):
-                    print(self.autoscaling.delete_auto_scaling_group(AutoScalingGroupName=group))
+                    print(self.autoscaling.delete_auto_scaling_group(AutoScalingGroupName=group, ForceDelete=True))
 
                 for group in existing_groups:
                     delete_asg(group)


### PR DESCRIPTION
[PLAT-7108](https://dominodatalab.atlassian.net/browse/PLAT-7108)
cdk to terraform convert : terraform imports fail with 
```
Error: with the retirement of EC2-Classic standard domain EC2 EIPs are no longer supported
```

This is due to an upstream change in the terraform `aws` provider.
The fix is to import the `eip` resource using its allocation id rather than its public ip.

Misc Changes:
* `PRIVATE_WITH_NAT` `PRIVATE` Subnet definition deprecated.
* `JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION` reduce noise.
* Forcing the main stack into `DELETE_FAILED` used to cascade to nested stacks. Fix by iterating through nested stacks.
* Adds `ForceDelete` to ASG to mitigate:
```
botocore.errorfactory.ScalingActivityInProgressFault: An error occurred (ScalingActivityInProgress) when calling the DeleteAutoScalingGroup operation: You cannot delete an AutoScalingGroup while there are scaling activities in progress for that group.
```